### PR TITLE
update deploy scripts to handle mainnet contract deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "deploy-local": "truffle migrate && truffle exec scripts/create_markets.js --network ${NETWORK:-development}",
     "deploy-kovan": "NETWORK=kovan npm run deploy-local",
     "deploy-rinkeby": "NETWORK=rinkeby npm run deploy-local",
+    "deploy-mainnet": "truffle migrate && truffle exec scripts/mainnet_create_markets.js --network mainnet",
     "transfer-ownership-local": "truffle exec scripts/transfer_ownership.js --network ${NETWORK:-development}",
     "transfer-ownership-rinkeby": "NETWORK=rinkeby npm run transfer-ownership-local",
+    "transfer-ownership-mainnet": "NETWORK=mainnet npm run transfer-ownership-local",
     "clean:dependencies": "rm -rf ./node_modules && rm -rf ./*/**/node_modules",
     "clean:dist": "rm -rf ./*/**/dist && rm -rf ./packages/contracts/build && rm -rf ./packages/contracts/src/ethers",
     "clean": "npm run clean:dependencies && npm run clean:dist"

--- a/scripts/mainnet_create_markets.js
+++ b/scripts/mainnet_create_markets.js
@@ -1,0 +1,159 @@
+const IERC20 = artifacts.require("IERC20")
+const MarketsRegistry = artifacts.require("MarketsRegistry")
+const Market = artifacts.require("Market")
+const Proxy = artifacts.require("Proxy")
+const AggregatorV3Interface = artifacts.require("AggregatorV3Interface")
+const MinterAmm = artifacts.require("MinterAmm")
+
+const { delay, getNetworkName } = require("./utils")
+const marketSetupData = require("./mainnet_market_setup_data.json")
+
+/**
+ * Deploy logic contracts and initialize market registry
+ * To grab the deployed instance of the registry with Truffle tooling, you can use the deployed Proxy Contract
+ */
+async function run() {
+  const network = await getNetworkName(await web3.eth.net.getId())
+
+  if (network != "mainnet") {
+    throw new Error("non-mainnet network used for mainnet deployment script!")
+  }
+
+  const tokenImpl = await SimpleToken.deployed()
+  const marketImpl = await Market.deployed()
+  const marketRegistryImpl = await MarketsRegistry.deployed()
+  const ammImpl = await MinterAmm.deployed()
+
+  // https://etherscan.io/token/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599
+  const WBTCToken = await IERC20.at(
+    "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+  )
+
+  // https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
+  const USDCToken = await IERC20.at(
+    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  )
+
+  console.log(`Setting up proxy pointing at the market registry logic`)
+  const proxyContract = await Proxy.new(marketRegistryImpl.address)
+  console.log(`Initializing MarketsRegistry`)
+  const deployedMarketsRegistry = await MarketsRegistry.at(
+    proxyContract.address,
+  )
+
+  const result = await deployedMarketsRegistry.initialize(
+    tokenImpl.address,
+    marketImpl.address,
+    ammImpl.address,
+  )
+
+  console.log(
+    `Market registry is up and running at address ${deployedMarketsRegistry.address}, initialized with tx id ${result.tx}`,
+  )
+
+  let priceOracle
+  if (network == "mainnet") {
+    console.log("connecting to mainnet oracle")
+    // see https://etherscan.io/address/0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c
+    priceOracle = await AggregatorV3Interface.at(
+      "0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c",
+    )
+  } else if (network == "kovan") {
+    console.log("connecting to kovan oracle")
+    // see https://kovan.etherscan.io/address/0x6135b13325bfC4B00278B4abC5e20bbce2D6580e
+    priceOracle = await AggregatorV3Interface.at(
+      "0x6135b13325bfC4B00278B4abC5e20bbce2D6580e",
+    )
+  } else if (network == "rinkeby") {
+    console.log("connecting to rinkeby oracle")
+    // https://rinkeby.etherscan.io/address/0xECe365B379E1dD183B20fc5f022230C044d51404
+    priceOracle = await AggregatorV3Interface.at(
+      "0xECe365B379E1dD183B20fc5f022230C044d51404",
+    )
+  } else if (network == "development") {
+    console.log("deploying price oracle")
+    priceOracle = await MockPriceOracle.deployed() // 8 decimals for WBTC's 8 decimals
+    await priceOracle.setLatestAnswer(14_000 * 10 ** 8) // hardcode to $14000
+    console.log("completed price oracle deploy")
+  }
+
+  // wait for 10 seconds for infura to catchup
+  console.log("waiting for infura to catchup on latest deployments...")
+  await delay(10 * 1000)
+
+  console.log("deploying 2 AMMs, one for WBTC-USDC and another for USDC-WBTC")
+  let ammWBTCUSDC
+  let ammUSDCWBTC
+  let ret = await deployedMarketsRegistry.createAmm(
+    priceOracle.address,
+    USDCToken.address,
+    WBTCToken.address,
+    0,
+    false,
+  )
+  let ammAddress = ret.logs[2].args["0"]
+  ammWBTCUSDC = await MinterAmm.at(ammAddress)
+
+  // set deposit limits and whitelist LPs for first round
+  await ammWBTCUSDC.setEnforceDepositLimits(true, "62440000") // 0.6244 BTC ~ $10K
+
+  ret = await deployedMarketsRegistry.createAmm(
+    priceOracle.address,
+    WBTCToken.address,
+    USDCToken.address,
+    0,
+    true,
+  )
+
+  ammAddress = ret.logs[2].args["0"]
+  ammUSDCWBTC = await MinterAmm.at(ammAddress)
+
+  // set deposit limits and whitelist LPs for first round
+  await ammUSDCWBTC.setEnforceDepositLimits(true, "10000000000") // $10K
+
+  console.log("completed AMM deploy")
+
+  // call createMarket several times to setup example markets
+  for (let marketData of marketSetupData) {
+    let collateralToken
+    let paymentToken
+    let amm
+    if (marketData.marketName.includes(".C.")) {
+      // it's a CALL, so the collateral is WBTC
+      collateralToken = WBTCToken
+      paymentToken = USDCToken
+      amm = ammWBTCUSDC
+    } else {
+      // it's a PUT, so the collateral is USDC
+      collateralToken = USDCToken
+      paymentToken = WBTCToken
+      amm = ammUSDCWBTC
+    }
+    const res = await deployedMarketsRegistry.createMarket(
+      marketData.marketName,
+      collateralToken.address,
+      paymentToken.address,
+      marketData.marketStyle,
+      marketData.priceRatio,
+      marketData.expirationDate,
+      marketData.exerciseFeeBasisPoints,
+      marketData.closeFeeBasisPoints,
+      marketData.claimFeeBasisPoints,
+      amm.address,
+    )
+    console.log(
+      `created market with marketName: ${marketData.marketName} with tx id: ${res.tx}`,
+    )
+  }
+
+  console.log("completed deploy of 2 AMM contracts and multiple Markets")
+}
+
+module.exports = async (callback) => {
+  try {
+    await run()
+    callback()
+  } catch (e) {
+    callback(e)
+  }
+}

--- a/scripts/mainnet_market_setup_data.json
+++ b/scripts/mainnet_market_setup_data.json
@@ -1,0 +1,39 @@
+[
+  {
+    "marketName": "USDC.WBTC.20201214.C.17000",
+    "priceRatio": "170000000000000000000",
+    "expirationDate": 1608040800,
+    "marketStyle": 1,
+    "exerciseFeeBasisPoints": 0,
+    "closeFeeBasisPoints": 0,
+    "claimFeeBasisPoints": 0
+  },
+  {
+    "marketName": "USDC.WBTC.20201214.C.16000",
+    "priceRatio": "160000000000000000000",
+    "expirationDate": 1608040800,
+    "marketStyle": 1,
+    "exerciseFeeBasisPoints": 0,
+    "closeFeeBasisPoints": 0,
+    "claimFeeBasisPoints": 0
+  },
+  {
+    "marketName": "USDC.WBTC.20201214.P.16000",
+    "priceRatio": "6250000000000000",
+
+    "expirationDate": 1608040800,
+    "marketStyle": 1,
+    "exerciseFeeBasisPoints": 0,
+    "closeFeeBasisPoints": 0,
+    "claimFeeBasisPoints": 0
+  },
+  {
+    "marketName": "USDC.WBTC.20201214.P.15000",
+    "priceRatio": "6666666666666670",
+    "expirationDate": 1608040800,
+    "marketStyle": 1,
+    "exerciseFeeBasisPoints": 0,
+    "closeFeeBasisPoints": 0,
+    "claimFeeBasisPoints": 0
+  }
+]

--- a/scripts/market_setup_data.json
+++ b/scripts/market_setup_data.json
@@ -2,7 +2,7 @@
   {
     "marketName": "USDC.WBTC.20201231.C.7000",
     "priceRatio": "70000000000000000000",
-    "expirationDate": 1609372800,
+    "expirationDate": 1608040800,
     "marketStyle": 1,
     "exerciseFeeBasisPoints": 0,
     "closeFeeBasisPoints": 0,
@@ -11,7 +11,7 @@
   {
     "marketName": "USDC.WBTC.20201231.P.16000",
     "priceRatio": "6250000000000000",
-    "expirationDate": 1609372800,
+    "expirationDate": 1608040800,
     "marketStyle": 1,
     "exerciseFeeBasisPoints": 0,
     "closeFeeBasisPoints": 0,
@@ -20,7 +20,7 @@
   {
     "marketName": "USDC.WBTC.20201231.P.18000",
     "priceRatio": "5555555555555560",
-    "expirationDate": 1609372800,
+    "expirationDate": 1608040800,
     "marketStyle": 1,
     "exerciseFeeBasisPoints": 0,
     "closeFeeBasisPoints": 0,
@@ -29,7 +29,7 @@
   {
     "marketName": "USDC.WBTC.20201231.P.7000",
     "priceRatio": "14285714285714286",
-    "expirationDate": 1609372800,
+    "expirationDate": 1608040800,
     "marketStyle": 1,
     "exerciseFeeBasisPoints": 0,
     "closeFeeBasisPoints": 0,
@@ -38,7 +38,7 @@
   {
     "marketName": "USDC.WBTC.20201231.C.17000",
     "priceRatio": "170000000000000000000",
-    "expirationDate": 1609372800,
+    "expirationDate": 1608040800,
     "marketStyle": 1,
     "exerciseFeeBasisPoints": 0,
     "closeFeeBasisPoints": 0,
@@ -47,7 +47,7 @@
   {
     "marketName": "USDC.WBTC.20201231.C.16000",
     "priceRatio": "160000000000000000000",
-    "expirationDate": 1609372800,
+    "expirationDate": 1608040800,
     "marketStyle": 1,
     "exerciseFeeBasisPoints": 0,
     "closeFeeBasisPoints": 0,
@@ -56,7 +56,7 @@
   {
     "marketName": "USDC.WBTC.20201231.C.18000",
     "priceRatio": "180000000000000000000",
-    "expirationDate": 1609372800,
+    "expirationDate": 1608040800,
     "marketStyle": 1,
     "exerciseFeeBasisPoints": 0,
     "closeFeeBasisPoints": 0,
@@ -65,7 +65,7 @@
   {
     "marketName": "USDC.WBTC.20201231.P.10000",
     "priceRatio": "10000000000000000",
-    "expirationDate": 1609372800,
+    "expirationDate": 1608040800,
     "marketStyle": 1,
     "exerciseFeeBasisPoints": 0,
     "closeFeeBasisPoints": 0,

--- a/scripts/transfer_ownership.js
+++ b/scripts/transfer_ownership.js
@@ -1,9 +1,7 @@
 const { request, gql } = require("graphql-request")
 
-const SimpleToken = artifacts.require("SimpleToken")
 const MarketsRegistry = artifacts.require("MarketsRegistry")
 const MinterAmm = artifacts.require("MinterAmm")
-const Market = artifacts.require("Market")
 
 const { getNetworkName } = require("./utils")
 
@@ -21,6 +19,16 @@ async function run() {
       "https://api.thegraph.com/subgraphs/name/sirenmarkets/protocol-rinkeby"
     multisigAddress = "0xCbb845969EcB2f89f2a736c785eB27F0B5B52410"
     marketsRegistryAddress = "0x79E93476cac62E76fEA27A7f7F8f7ea73b4B764d"
+  } else if (network == "mainnet") {
+    subgraphUrl =
+      "https://api.thegraph.com/subgraphs/name/sirenmarkets/protocol-mainnet"
+    multisigAddress = "0xd42dfEB13BDAe6120B99730cB8e5DEa18004A44b"
+    marketsRegistryAddress = "TODO" // update this!
+    if (marketsRegistryAddress === "TODO") {
+      throw new Error(
+        "must first run 'mainnet_create_markets.js script and deploy mainnet subgraph before transferring ownership",
+      )
+    }
   } else {
     throw new Error(`No configuration for network ${network}`)
   }

--- a/subgraph/config/mainnet.json
+++ b/subgraph/config/mainnet.json
@@ -1,0 +1,5 @@
+{
+  "network": "mainnet",
+  "marketsRegistryAddress": "TODO",
+  "marketsRegistryStartBlock": 99999999999
+}

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -12,6 +12,7 @@
     "deploy-local": "npm run prepare && graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 sirenmarkets/protocol",
     "deploy-kovan": "NETWORK=kovan NAME=protocol-kovan-v2 npm run deploy-remote",
     "deploy-rinkeby": "NETWORK=rinkeby NAME=protocol-rinkeby npm run deploy-remote",
+    "deploy-mainnet": "NETWORK=mainnet NAME=protocol npm run deploy-remote",
     "graph-auth": "graph auth https://api.thegraph.com/deploy/ --"
   },
   "dependencies": {


### PR DESCRIPTION
create a new truffle script for deploying and initializing the AMM's and 4 initial Markets on mainnet.

Note that once this merges, we can run the `mainnet_create_markets.js` script, but then we need to deploy the updated subgraph to mainnet, and then the deployer will need to create another PR  to update `marketsRegistryAddress` in `scripts/transfer_ownership.js` so that the transfer of ownership to the multisig address will work correctly