### PR TITLE
Add timelock contract examples

### DIFF
--- a/contracts/lockups/DaveyJonesLocker.sol
+++ b/contracts/lockups/DaveyJonesLocker.sol
@@ -1,0 +1,15 @@
+pragma solidity 0.6.12;
+
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/TokenTimelock.sol";
+
+contract DaveyJonesLocker is TokenTimelockUpgradeSafe {
+
+  constructor(IERC20 token, address beneficiary, uint256 releaseTime) public {
+    require(address(token) != address(0x0), "token Invalid");
+    require(beneficiary != address(0x0), "beneficiary Invalid");
+    
+    // Init the timelock
+    __TokenTimelock_init(token, beneficiary, releaseTime);
+  }
+
+}

--- a/test/lockups/timeLockTokens.js
+++ b/test/lockups/timeLockTokens.js
@@ -1,0 +1,44 @@
+const { time, expectRevert } = require("@openzeppelin/test-helpers")
+const DaveyJonesLocker = artifacts.require("DaveyJonesLocker")
+const SimpleToken = artifacts.require("SimpleToken")
+
+contract("Time Locks", (accounts) => {
+  const ownerAccount = accounts[0]
+  const aliceAccount = accounts[1]
+
+  it("Verifies Lock", async () => {
+    // Get the current block time
+    const currentTime = await time.latest()
+    const twoDays = 2 * 60 * 60 * 24
+
+    const collateralToken = await SimpleToken.new()
+    await collateralToken.initialize("Wrapped BTC", "WBTC", 8)
+
+    const deployedTimeLock = await DaveyJonesLocker.new(
+      collateralToken.address,
+      aliceAccount,
+      parseInt(currentTime) + twoDays,
+    )
+
+    await collateralToken.mint(deployedTimeLock.address, "100")
+
+    // Verify you can't pull them out before the expiration
+    await expectRevert(
+      deployedTimeLock.release(),
+      "TokenTimelock: current time is before release time",
+    )
+
+    // Fast forward
+    await time.increase(twoDays + 1)
+
+    // Verify the tokens are released
+    await deployedTimeLock.release()
+
+    // Verify alice has them
+    assert.equal(
+      await collateralToken.balanceOf.call(aliceAccount),
+      100,
+      "Alice should have gotten payment token",
+    )
+  })
+})


### PR DESCRIPTION
This adds a new timelock contract and shows how to use it with a unit test.

* Initialize contract with token address, beneficiary, and unlock time
* After unlock time, anyone can trigger tokens to be sent to user