### PR TITLE
Add ability to minteramm to store open markets and remove them when e…

### DIFF
--- a/contracts/amm/IAddMarketToAmm.sol
+++ b/contracts/amm/IAddMarketToAmm.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+interface IAddMarketToAmm {
+    function addMarket(address newMarketAddress) external;
+}

--- a/contracts/market/MarketsRegistry.sol
+++ b/contracts/market/MarketsRegistry.sol
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts-ethereum-package/contracts/access/Ownable.sol";
 import "../proxy/Proxy.sol";
 import "../proxy/Proxiable.sol";
 import "../amm/InitializeableAmm.sol";
+import "../amm/IAddMarketToAmm.sol";
 
 /**
  * The Markets Registry is responsible for creating and tracking markets
@@ -229,11 +230,23 @@ contract MarketsRegistry is OwnableUpgradeSafe, Proxiable, IMarketsRegistry {
         bytes32 assetPair = keccak256(abi.encode(address(_collateralToken), address(_paymentToken)));
         marketsByAssets[assetPair].push(address(newMarket));
 
+        //Add the market to the AMM handling the asset pair
+        addMarketToAmm(_amm, address(newMarket));
+
         // Emit the event
         emit MarketCreated(_marketName, address(newMarket), marketsByAssets[assetPair].length - 1);
 
         // Return the address of the market that was created
         return address(newMarket);
+    }
+
+    /**
+     * Add market to the amm handling the asset pair after creating it.
+     * @dev Refactored from createMarket as number of local variables exceeded 16.
+     */
+    function addMarketToAmm(address ammAddress,address newMarketAddress) internal{
+        IAddMarketToAmm amm = IAddMarketToAmm(ammAddress);
+        amm.addMarket(newMarketAddress);
     }
 
     /**


### PR DESCRIPTION
Add ability to minteramm to store open markets and remove them when expired

MinterAmm will hold a state variable openMarkets which will be called by the  MarketsRegistry when a new market is created. openMarkets will store the open markets for the asset pair. Expired markets are removed when getUnclaimedBalances is called

getUnclaimedBalances: Since dynamic arrays are not possible on memory, indices of first 10 expired markets are stored and markets corresponding to index are removed from openMarkets. The function and the calling functions looses the 'view' modifier as the storage is edited here.

Addressed previous comments

Solves : https://github.com/sirenmarkets/core/issues/33