### PR TITLE
use correct authentication for MinterAmm.addMarket.

### DIFF
--- a/contracts/amm/IAddMarketToAmm.sol
+++ b/contracts/amm/IAddMarketToAmm.sol
@@ -3,5 +3,5 @@
 pragma solidity 0.6.12;
 
 interface IAddMarketToAmm {
-    function addMarket(address newMarketAddress,address sender) external;
+    function addMarket(address newMarketAddress) external;
 }

--- a/contracts/amm/MinterAmm.sol
+++ b/contracts/amm/MinterAmm.sol
@@ -1190,8 +1190,8 @@ contract MinterAmm is InitializeableAmm,IAddMarketToAmm, OwnableUpgradeSafe, Pro
      * @dev Adds the address of market to the amm
      * This method is called by Market Registry when it is creating a new market
      */
-    function addMarket(address newMarketAddress,address sender) external override{
-        require(owner() == sender,'Only owner can call the method');
+    function addMarket(address newMarketAddress) external override {
+        require(msg.sender == address(registry), "Only registry can call addMarket");
         openMarkets.push(newMarketAddress);
     }
 }

--- a/contracts/market/MarketsRegistry.sol
+++ b/contracts/market/MarketsRegistry.sol
@@ -248,7 +248,7 @@ contract MarketsRegistry is OwnableUpgradeSafe, Proxiable, IMarketsRegistry {
      */
     function addMarketToAmm(address ammAddress,address newMarketAddress) internal{
         IAddMarketToAmm amm = IAddMarketToAmm(ammAddress);
-        amm.addMarket(newMarketAddress,tx.origin);
+        amm.addMarket(newMarketAddress);
     }
 
     /**

--- a/scripts/create_markets.js
+++ b/scripts/create_markets.js
@@ -123,14 +123,6 @@ async function run() {
   // set deposit limits and whitelist LPs
   await ammWBTCUSDC.setEnforceDepositLimits(true, "70000000") // 0.7 BTC ~ $10K
   await ammUSDCWBTC.setEnforceDepositLimits(true, "10000000000") // $10K
-  await ammWBTCUSDC.setCapitalDepositLimit(
-    lpAccounts,
-    lpAccounts.map((a) => true),
-  )
-  await ammUSDCWBTC.setCapitalDepositLimit(
-    lpAccounts,
-    lpAccounts.map((a) => true),
-  )
 
   // call createMarket several times to setup example markets
   for (let marketData of marketSetupData) {

--- a/test/amm/minterAmmRemoveExpired.js
+++ b/test/amm/minterAmmRemoveExpired.js
@@ -93,7 +93,7 @@ contract("Minter AMM Remove expired markets", (accounts) => {
     const expiration = Number(await time.latest()) + THIRTY_DAYS // 30 days from now;
     const STRIKE_RATIO_1 = 5000
 
-    // Non-owner shouldn't add market to the amm
+    // Non-owner shouldn't be able to create a market
     await expectRevert.unspecified(
       deployedMarketsRegistry.createMarket(
         NAME_1,
@@ -110,7 +110,7 @@ contract("Minter AMM Remove expired markets", (accounts) => {
       ),
     )
 
-    //Add market to the amm
+    // Add market to the amm
     await deployedMarketsRegistry.createMarket(
       NAME_1,
       collateralToken.address,
@@ -127,10 +127,20 @@ contract("Minter AMM Remove expired markets", (accounts) => {
     let markets = await deployedAmm.getMarkets()
     is_markets_added = markets.includes(marketAddress1)
     assert.equal(is_markets_added, true, "Markets are not added to MinterAmm")
+
+    // Non-registry shouldn't be able to add a market to the AMM
+    await expectRevert(
+      deployedAmm.addMarket(marketAddress1),
+      "Only registry can call addMarket",
+    )
+    await expectRevert(
+      deployedAmm.addMarket(marketAddress1, { from: bobAccount }),
+      "Only registry can call addMarket",
+    )
   })
 
   it("All markets expired", async () => {
-    //set the expiration
+    // set the expiration
     const expiration = Number(await time.latest()) + THIRTY_DAYS // 30 days from now;
 
     const STRIKE_RATIO_1 = 5000


### PR DESCRIPTION
Prior to this commit we were not properly validating the caller on addMarket, and any address could pass any argument they wanted for 'sender' and add as many Markets as they wished.
Now we properly check that the calling contract is the MarketsRegistry.