### PR TITLE
add seriesId field to AMM trade subgraph events.

### DIFF
--- a/subgraph/generated/AmmFactory/AmmFactory.ts
+++ b/subgraph/generated/AmmFactory/AmmFactory.ts
@@ -7,476 +7,480 @@ import {
   Entity,
   Bytes,
   Address,
-  BigInt,
-} from "@graphprotocol/graph-ts"
+  BigInt
+} from "@graphprotocol/graph-ts";
 
 export class AmmCreated extends ethereum.Event {
   get params(): AmmCreated__Params {
-    return new AmmCreated__Params(this)
+    return new AmmCreated__Params(this);
   }
 }
 
 export class AmmCreated__Params {
-  _event: AmmCreated
+  _event: AmmCreated;
 
   constructor(event: AmmCreated) {
-    this._event = event
+    this._event = event;
   }
 
   get amm(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class AmmImplementationUpdated extends ethereum.Event {
   get params(): AmmImplementationUpdated__Params {
-    return new AmmImplementationUpdated__Params(this)
+    return new AmmImplementationUpdated__Params(this);
   }
 }
 
 export class AmmImplementationUpdated__Params {
-  _event: AmmImplementationUpdated
+  _event: AmmImplementationUpdated;
 
   constructor(event: AmmImplementationUpdated) {
-    this._event = event
+    this._event = event;
   }
 
   get newAddress(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class CodeAddressUpdated extends ethereum.Event {
   get params(): CodeAddressUpdated__Params {
-    return new CodeAddressUpdated__Params(this)
+    return new CodeAddressUpdated__Params(this);
   }
 }
 
 export class CodeAddressUpdated__Params {
-  _event: CodeAddressUpdated
+  _event: CodeAddressUpdated;
 
   constructor(event: CodeAddressUpdated) {
-    this._event = event
+    this._event = event;
   }
 
   get newAddress(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class OwnershipTransferred extends ethereum.Event {
   get params(): OwnershipTransferred__Params {
-    return new OwnershipTransferred__Params(this)
+    return new OwnershipTransferred__Params(this);
   }
 }
 
 export class OwnershipTransferred__Params {
-  _event: OwnershipTransferred
+  _event: OwnershipTransferred;
 
   constructor(event: OwnershipTransferred) {
-    this._event = event
+    this._event = event;
   }
 
   get previousOwner(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get newOwner(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 }
 
 export class TokenImplementationUpdated extends ethereum.Event {
   get params(): TokenImplementationUpdated__Params {
-    return new TokenImplementationUpdated__Params(this)
+    return new TokenImplementationUpdated__Params(this);
   }
 }
 
 export class TokenImplementationUpdated__Params {
-  _event: TokenImplementationUpdated
+  _event: TokenImplementationUpdated;
 
   constructor(event: TokenImplementationUpdated) {
-    this._event = event
+    this._event = event;
   }
 
   get newAddress(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class AmmFactory extends ethereum.SmartContract {
   static bind(address: Address): AmmFactory {
-    return new AmmFactory("AmmFactory", address)
+    return new AmmFactory("AmmFactory", address);
   }
 
   ammImplementation(): Address {
     let result = super.call(
       "ammImplementation",
       "ammImplementation():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_ammImplementation(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "ammImplementation",
       "ammImplementation():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   amms(param0: Bytes): Address {
     let result = super.call("amms", "amms(bytes32):(address)", [
-      ethereum.Value.fromFixedBytes(param0),
-    ])
+      ethereum.Value.fromFixedBytes(param0)
+    ]);
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_amms(param0: Bytes): ethereum.CallResult<Address> {
     let result = super.tryCall("amms", "amms(bytes32):(address)", [
-      ethereum.Value.fromFixedBytes(param0),
-    ])
+      ethereum.Value.fromFixedBytes(param0)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   getLogicAddress(): Address {
     let result = super.call(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_getLogicAddress(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   owner(): Address {
-    let result = super.call("owner", "owner():(address)", [])
+    let result = super.call("owner", "owner():(address)", []);
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_owner(): ethereum.CallResult<Address> {
-    let result = super.tryCall("owner", "owner():(address)", [])
+    let result = super.tryCall("owner", "owner():(address)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   proxiableUUID(): Bytes {
-    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_proxiableUUID(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.tryCall(
+      "proxiableUUID",
+      "proxiableUUID():(bytes32)",
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   seriesController(): Address {
     let result = super.call(
       "seriesController",
       "seriesController():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_seriesController(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "seriesController",
       "seriesController():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   tokenImplementation(): Address {
     let result = super.call(
       "tokenImplementation",
       "tokenImplementation():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_tokenImplementation(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "tokenImplementation",
       "tokenImplementation():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 }
 
 export class CreateAmmCall extends ethereum.Call {
   get inputs(): CreateAmmCall__Inputs {
-    return new CreateAmmCall__Inputs(this)
+    return new CreateAmmCall__Inputs(this);
   }
 
   get outputs(): CreateAmmCall__Outputs {
-    return new CreateAmmCall__Outputs(this)
+    return new CreateAmmCall__Outputs(this);
   }
 }
 
 export class CreateAmmCall__Inputs {
-  _call: CreateAmmCall
+  _call: CreateAmmCall;
 
   constructor(call: CreateAmmCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _sirenPriceOracle(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get _underlyingToken(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get _priceToken(): Address {
-    return this._call.inputValues[2].value.toAddress()
+    return this._call.inputValues[2].value.toAddress();
   }
 
   get _collateralToken(): Address {
-    return this._call.inputValues[3].value.toAddress()
+    return this._call.inputValues[3].value.toAddress();
   }
 
   get _tradeFeeBasisPoints(): i32 {
-    return this._call.inputValues[4].value.toI32()
+    return this._call.inputValues[4].value.toI32();
   }
 }
 
 export class CreateAmmCall__Outputs {
-  _call: CreateAmmCall
+  _call: CreateAmmCall;
 
   constructor(call: CreateAmmCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class InitializeCall extends ethereum.Call {
   get inputs(): InitializeCall__Inputs {
-    return new InitializeCall__Inputs(this)
+    return new InitializeCall__Inputs(this);
   }
 
   get outputs(): InitializeCall__Outputs {
-    return new InitializeCall__Outputs(this)
+    return new InitializeCall__Outputs(this);
   }
 }
 
 export class InitializeCall__Inputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _ammImplementation(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get _tokenImplementation(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get _seriesController(): Address {
-    return this._call.inputValues[2].value.toAddress()
+    return this._call.inputValues[2].value.toAddress();
   }
 }
 
 export class InitializeCall__Outputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceOwnershipCall extends ethereum.Call {
   get inputs(): RenounceOwnershipCall__Inputs {
-    return new RenounceOwnershipCall__Inputs(this)
+    return new RenounceOwnershipCall__Inputs(this);
   }
 
   get outputs(): RenounceOwnershipCall__Outputs {
-    return new RenounceOwnershipCall__Outputs(this)
+    return new RenounceOwnershipCall__Outputs(this);
   }
 }
 
 export class RenounceOwnershipCall__Inputs {
-  _call: RenounceOwnershipCall
+  _call: RenounceOwnershipCall;
 
   constructor(call: RenounceOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceOwnershipCall__Outputs {
-  _call: RenounceOwnershipCall
+  _call: RenounceOwnershipCall;
 
   constructor(call: RenounceOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class TransferOwnershipCall extends ethereum.Call {
   get inputs(): TransferOwnershipCall__Inputs {
-    return new TransferOwnershipCall__Inputs(this)
+    return new TransferOwnershipCall__Inputs(this);
   }
 
   get outputs(): TransferOwnershipCall__Outputs {
-    return new TransferOwnershipCall__Outputs(this)
+    return new TransferOwnershipCall__Outputs(this);
   }
 }
 
 export class TransferOwnershipCall__Inputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 
   get newOwner(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class TransferOwnershipCall__Outputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UpdateAmmImplementationCall extends ethereum.Call {
   get inputs(): UpdateAmmImplementationCall__Inputs {
-    return new UpdateAmmImplementationCall__Inputs(this)
+    return new UpdateAmmImplementationCall__Inputs(this);
   }
 
   get outputs(): UpdateAmmImplementationCall__Outputs {
-    return new UpdateAmmImplementationCall__Outputs(this)
+    return new UpdateAmmImplementationCall__Outputs(this);
   }
 }
 
 export class UpdateAmmImplementationCall__Inputs {
-  _call: UpdateAmmImplementationCall
+  _call: UpdateAmmImplementationCall;
 
   constructor(call: UpdateAmmImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 
   get newAmmImplementation(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class UpdateAmmImplementationCall__Outputs {
-  _call: UpdateAmmImplementationCall
+  _call: UpdateAmmImplementationCall;
 
   constructor(call: UpdateAmmImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UpdateImplementationCall extends ethereum.Call {
   get inputs(): UpdateImplementationCall__Inputs {
-    return new UpdateImplementationCall__Inputs(this)
+    return new UpdateImplementationCall__Inputs(this);
   }
 
   get outputs(): UpdateImplementationCall__Outputs {
-    return new UpdateImplementationCall__Outputs(this)
+    return new UpdateImplementationCall__Outputs(this);
   }
 }
 
 export class UpdateImplementationCall__Inputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _newImplementation(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class UpdateImplementationCall__Outputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UpdateTokenImplementationCall extends ethereum.Call {
   get inputs(): UpdateTokenImplementationCall__Inputs {
-    return new UpdateTokenImplementationCall__Inputs(this)
+    return new UpdateTokenImplementationCall__Inputs(this);
   }
 
   get outputs(): UpdateTokenImplementationCall__Outputs {
-    return new UpdateTokenImplementationCall__Outputs(this)
+    return new UpdateTokenImplementationCall__Outputs(this);
   }
 }
 
 export class UpdateTokenImplementationCall__Inputs {
-  _call: UpdateTokenImplementationCall
+  _call: UpdateTokenImplementationCall;
 
   constructor(call: UpdateTokenImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 
   get newTokenImplementation(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class UpdateTokenImplementationCall__Outputs {
-  _call: UpdateTokenImplementationCall
+  _call: UpdateTokenImplementationCall;
 
   constructor(call: UpdateTokenImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 }

--- a/subgraph/generated/ERC1155Controller/ERC1155Controller.ts
+++ b/subgraph/generated/ERC1155Controller/ERC1155Controller.ts
@@ -7,331 +7,331 @@ import {
   Entity,
   Bytes,
   Address,
-  BigInt,
-} from "@graphprotocol/graph-ts"
+  BigInt
+} from "@graphprotocol/graph-ts";
 
 export class ApprovalForAll extends ethereum.Event {
   get params(): ApprovalForAll__Params {
-    return new ApprovalForAll__Params(this)
+    return new ApprovalForAll__Params(this);
   }
 }
 
 export class ApprovalForAll__Params {
-  _event: ApprovalForAll
+  _event: ApprovalForAll;
 
   constructor(event: ApprovalForAll) {
-    this._event = event
+    this._event = event;
   }
 
   get account(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get operator(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get approved(): boolean {
-    return this._event.parameters[2].value.toBoolean()
+    return this._event.parameters[2].value.toBoolean();
   }
 }
 
 export class CodeAddressUpdated extends ethereum.Event {
   get params(): CodeAddressUpdated__Params {
-    return new CodeAddressUpdated__Params(this)
+    return new CodeAddressUpdated__Params(this);
   }
 }
 
 export class CodeAddressUpdated__Params {
-  _event: CodeAddressUpdated
+  _event: CodeAddressUpdated;
 
   constructor(event: CodeAddressUpdated) {
-    this._event = event
+    this._event = event;
   }
 
   get newAddress(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class ERC1155ControllerInitialized extends ethereum.Event {
   get params(): ERC1155ControllerInitialized__Params {
-    return new ERC1155ControllerInitialized__Params(this)
+    return new ERC1155ControllerInitialized__Params(this);
   }
 }
 
 export class ERC1155ControllerInitialized__Params {
-  _event: ERC1155ControllerInitialized
+  _event: ERC1155ControllerInitialized;
 
   constructor(event: ERC1155ControllerInitialized) {
-    this._event = event
+    this._event = event;
   }
 
   get controller(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class Paused extends ethereum.Event {
   get params(): Paused__Params {
-    return new Paused__Params(this)
+    return new Paused__Params(this);
   }
 }
 
 export class Paused__Params {
-  _event: Paused
+  _event: Paused;
 
   constructor(event: Paused) {
-    this._event = event
+    this._event = event;
   }
 
   get account(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class RoleAdminChanged extends ethereum.Event {
   get params(): RoleAdminChanged__Params {
-    return new RoleAdminChanged__Params(this)
+    return new RoleAdminChanged__Params(this);
   }
 }
 
 export class RoleAdminChanged__Params {
-  _event: RoleAdminChanged
+  _event: RoleAdminChanged;
 
   constructor(event: RoleAdminChanged) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get previousAdminRole(): Bytes {
-    return this._event.parameters[1].value.toBytes()
+    return this._event.parameters[1].value.toBytes();
   }
 
   get newAdminRole(): Bytes {
-    return this._event.parameters[2].value.toBytes()
+    return this._event.parameters[2].value.toBytes();
   }
 }
 
 export class RoleGranted extends ethereum.Event {
   get params(): RoleGranted__Params {
-    return new RoleGranted__Params(this)
+    return new RoleGranted__Params(this);
   }
 }
 
 export class RoleGranted__Params {
-  _event: RoleGranted
+  _event: RoleGranted;
 
   constructor(event: RoleGranted) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class RoleRevoked extends ethereum.Event {
   get params(): RoleRevoked__Params {
-    return new RoleRevoked__Params(this)
+    return new RoleRevoked__Params(this);
   }
 }
 
 export class RoleRevoked__Params {
-  _event: RoleRevoked
+  _event: RoleRevoked;
 
   constructor(event: RoleRevoked) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class TransferBatch extends ethereum.Event {
   get params(): TransferBatch__Params {
-    return new TransferBatch__Params(this)
+    return new TransferBatch__Params(this);
   }
 }
 
 export class TransferBatch__Params {
-  _event: TransferBatch
+  _event: TransferBatch;
 
   constructor(event: TransferBatch) {
-    this._event = event
+    this._event = event;
   }
 
   get operator(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get from(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get to(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 
   get ids(): Array<BigInt> {
-    return this._event.parameters[3].value.toBigIntArray()
+    return this._event.parameters[3].value.toBigIntArray();
   }
 
   get values(): Array<BigInt> {
-    return this._event.parameters[4].value.toBigIntArray()
+    return this._event.parameters[4].value.toBigIntArray();
   }
 }
 
 export class TransferSingle extends ethereum.Event {
   get params(): TransferSingle__Params {
-    return new TransferSingle__Params(this)
+    return new TransferSingle__Params(this);
   }
 }
 
 export class TransferSingle__Params {
-  _event: TransferSingle
+  _event: TransferSingle;
 
   constructor(event: TransferSingle) {
-    this._event = event
+    this._event = event;
   }
 
   get operator(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get from(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get to(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 
   get id(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 
   get value(): BigInt {
-    return this._event.parameters[4].value.toBigInt()
+    return this._event.parameters[4].value.toBigInt();
   }
 }
 
 export class URI extends ethereum.Event {
   get params(): URI__Params {
-    return new URI__Params(this)
+    return new URI__Params(this);
   }
 }
 
 export class URI__Params {
-  _event: URI
+  _event: URI;
 
   constructor(event: URI) {
-    this._event = event
+    this._event = event;
   }
 
   get value(): string {
-    return this._event.parameters[0].value.toString()
+    return this._event.parameters[0].value.toString();
   }
 
   get id(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 }
 
 export class Unpaused extends ethereum.Event {
   get params(): Unpaused__Params {
-    return new Unpaused__Params(this)
+    return new Unpaused__Params(this);
   }
 }
 
 export class Unpaused__Params {
-  _event: Unpaused
+  _event: Unpaused;
 
   constructor(event: Unpaused) {
-    this._event = event
+    this._event = event;
   }
 
   get account(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class ERC1155Controller extends ethereum.SmartContract {
   static bind(address: Address): ERC1155Controller {
-    return new ERC1155Controller("ERC1155Controller", address)
+    return new ERC1155Controller("ERC1155Controller", address);
   }
 
   DEFAULT_ADMIN_ROLE(): Bytes {
     let result = super.call(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_DEFAULT_ADMIN_ROLE(): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   MINTER_ROLE(): Bytes {
-    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_MINTER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   PAUSER_ROLE(): Bytes {
-    let result = super.call("PAUSER_ROLE", "PAUSER_ROLE():(bytes32)", [])
+    let result = super.call("PAUSER_ROLE", "PAUSER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_PAUSER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("PAUSER_ROLE", "PAUSER_ROLE():(bytes32)", [])
+    let result = super.tryCall("PAUSER_ROLE", "PAUSER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   balanceOf(account: Address, id: BigInt): BigInt {
@@ -340,11 +340,11 @@ export class ERC1155Controller extends ethereum.SmartContract {
       "balanceOf(address,uint256):(uint256)",
       [
         ethereum.Value.fromAddress(account),
-        ethereum.Value.fromUnsignedBigInt(id),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(id)
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_balanceOf(account: Address, id: BigInt): ethereum.CallResult<BigInt> {
@@ -353,14 +353,14 @@ export class ERC1155Controller extends ethereum.SmartContract {
       "balanceOf(address,uint256):(uint256)",
       [
         ethereum.Value.fromAddress(account),
-        ethereum.Value.fromUnsignedBigInt(id),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(id)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   balanceOfBatch(accounts: Array<Address>, ids: Array<BigInt>): Array<BigInt> {
@@ -369,74 +369,74 @@ export class ERC1155Controller extends ethereum.SmartContract {
       "balanceOfBatch(address[],uint256[]):(uint256[])",
       [
         ethereum.Value.fromAddressArray(accounts),
-        ethereum.Value.fromUnsignedBigIntArray(ids),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigIntArray(ids)
+      ]
+    );
 
-    return result[0].toBigIntArray()
+    return result[0].toBigIntArray();
   }
 
   try_balanceOfBatch(
     accounts: Array<Address>,
-    ids: Array<BigInt>,
+    ids: Array<BigInt>
   ): ethereum.CallResult<Array<BigInt>> {
     let result = super.tryCall(
       "balanceOfBatch",
       "balanceOfBatch(address[],uint256[]):(uint256[])",
       [
         ethereum.Value.fromAddressArray(accounts),
-        ethereum.Value.fromUnsignedBigIntArray(ids),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigIntArray(ids)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigIntArray())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigIntArray());
   }
 
   getLogicAddress(): Address {
     let result = super.call(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_getLogicAddress(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   getRoleAdmin(role: Bytes): Bytes {
     let result = super.call("getRoleAdmin", "getRoleAdmin(bytes32):(bytes32)", [
-      ethereum.Value.fromFixedBytes(role),
-    ])
+      ethereum.Value.fromFixedBytes(role)
+    ]);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_getRoleAdmin(role: Bytes): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "getRoleAdmin",
       "getRoleAdmin(bytes32):(bytes32)",
-      [ethereum.Value.fromFixedBytes(role)],
-    )
+      [ethereum.Value.fromFixedBytes(role)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   getRoleMember(role: Bytes, index: BigInt): Address {
@@ -445,11 +445,11 @@ export class ERC1155Controller extends ethereum.SmartContract {
       "getRoleMember(bytes32,uint256):(address)",
       [
         ethereum.Value.fromFixedBytes(role),
-        ethereum.Value.fromUnsignedBigInt(index),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(index)
+      ]
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_getRoleMember(role: Bytes, index: BigInt): ethereum.CallResult<Address> {
@@ -458,58 +458,58 @@ export class ERC1155Controller extends ethereum.SmartContract {
       "getRoleMember(bytes32,uint256):(address)",
       [
         ethereum.Value.fromFixedBytes(role),
-        ethereum.Value.fromUnsignedBigInt(index),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(index)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   getRoleMemberCount(role: Bytes): BigInt {
     let result = super.call(
       "getRoleMemberCount",
       "getRoleMemberCount(bytes32):(uint256)",
-      [ethereum.Value.fromFixedBytes(role)],
-    )
+      [ethereum.Value.fromFixedBytes(role)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_getRoleMemberCount(role: Bytes): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "getRoleMemberCount",
       "getRoleMemberCount(bytes32):(uint256)",
-      [ethereum.Value.fromFixedBytes(role)],
-    )
+      [ethereum.Value.fromFixedBytes(role)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   hasRole(role: Bytes, account: Address): boolean {
     let result = super.call("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_hasRole(role: Bytes, account: Address): ethereum.CallResult<boolean> {
     let result = super.tryCall("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   isApprovedForAll(account: Address, operator: Address): boolean {
@@ -518,736 +518,740 @@ export class ERC1155Controller extends ethereum.SmartContract {
       "isApprovedForAll(address,address):(bool)",
       [
         ethereum.Value.fromAddress(account),
-        ethereum.Value.fromAddress(operator),
-      ],
-    )
+        ethereum.Value.fromAddress(operator)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_isApprovedForAll(
     account: Address,
-    operator: Address,
+    operator: Address
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "isApprovedForAll",
       "isApprovedForAll(address,address):(bool)",
       [
         ethereum.Value.fromAddress(account),
-        ethereum.Value.fromAddress(operator),
-      ],
-    )
+        ethereum.Value.fromAddress(operator)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   optionTokenTotalSupplies(param0: BigInt): BigInt {
     let result = super.call(
       "optionTokenTotalSupplies",
       "optionTokenTotalSupplies(uint256):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(param0)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(param0)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_optionTokenTotalSupplies(param0: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "optionTokenTotalSupplies",
       "optionTokenTotalSupplies(uint256):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(param0)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(param0)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   optionTokenTotalSupply(id: BigInt): BigInt {
     let result = super.call(
       "optionTokenTotalSupply",
       "optionTokenTotalSupply(uint256):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(id)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(id)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_optionTokenTotalSupply(id: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "optionTokenTotalSupply",
       "optionTokenTotalSupply(uint256):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(id)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(id)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   optionTokenTotalSupplyBatch(ids: Array<BigInt>): Array<BigInt> {
     let result = super.call(
       "optionTokenTotalSupplyBatch",
       "optionTokenTotalSupplyBatch(uint256[]):(uint256[])",
-      [ethereum.Value.fromUnsignedBigIntArray(ids)],
-    )
+      [ethereum.Value.fromUnsignedBigIntArray(ids)]
+    );
 
-    return result[0].toBigIntArray()
+    return result[0].toBigIntArray();
   }
 
   try_optionTokenTotalSupplyBatch(
-    ids: Array<BigInt>,
+    ids: Array<BigInt>
   ): ethereum.CallResult<Array<BigInt>> {
     let result = super.tryCall(
       "optionTokenTotalSupplyBatch",
       "optionTokenTotalSupplyBatch(uint256[]):(uint256[])",
-      [ethereum.Value.fromUnsignedBigIntArray(ids)],
-    )
+      [ethereum.Value.fromUnsignedBigIntArray(ids)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigIntArray())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigIntArray());
   }
 
   paused(): boolean {
-    let result = super.call("paused", "paused():(bool)", [])
+    let result = super.call("paused", "paused():(bool)", []);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_paused(): ethereum.CallResult<boolean> {
-    let result = super.tryCall("paused", "paused():(bool)", [])
+    let result = super.tryCall("paused", "paused():(bool)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   proxiableUUID(): Bytes {
-    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_proxiableUUID(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.tryCall(
+      "proxiableUUID",
+      "proxiableUUID():(bytes32)",
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   supportsInterface(interfaceId: Bytes): boolean {
     let result = super.call(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_supportsInterface(interfaceId: Bytes): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   uri(param0: BigInt): string {
     let result = super.call("uri", "uri(uint256):(string)", [
-      ethereum.Value.fromUnsignedBigInt(param0),
-    ])
+      ethereum.Value.fromUnsignedBigInt(param0)
+    ]);
 
-    return result[0].toString()
+    return result[0].toString();
   }
 
   try_uri(param0: BigInt): ethereum.CallResult<string> {
     let result = super.tryCall("uri", "uri(uint256):(string)", [
-      ethereum.Value.fromUnsignedBigInt(param0),
-    ])
+      ethereum.Value.fromUnsignedBigInt(param0)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toString())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toString());
   }
 }
 
 export class __ERC1155Controller_initCall extends ethereum.Call {
   get inputs(): __ERC1155Controller_initCall__Inputs {
-    return new __ERC1155Controller_initCall__Inputs(this)
+    return new __ERC1155Controller_initCall__Inputs(this);
   }
 
   get outputs(): __ERC1155Controller_initCall__Outputs {
-    return new __ERC1155Controller_initCall__Outputs(this)
+    return new __ERC1155Controller_initCall__Outputs(this);
   }
 }
 
 export class __ERC1155Controller_initCall__Inputs {
-  _call: __ERC1155Controller_initCall
+  _call: __ERC1155Controller_initCall;
 
   constructor(call: __ERC1155Controller_initCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _uri(): string {
-    return this._call.inputValues[0].value.toString()
+    return this._call.inputValues[0].value.toString();
   }
 
   get _seriesController(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class __ERC1155Controller_initCall__Outputs {
-  _call: __ERC1155Controller_initCall
+  _call: __ERC1155Controller_initCall;
 
   constructor(call: __ERC1155Controller_initCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class BurnCall extends ethereum.Call {
   get inputs(): BurnCall__Inputs {
-    return new BurnCall__Inputs(this)
+    return new BurnCall__Inputs(this);
   }
 
   get outputs(): BurnCall__Outputs {
-    return new BurnCall__Outputs(this)
+    return new BurnCall__Outputs(this);
   }
 }
 
 export class BurnCall__Inputs {
-  _call: BurnCall
+  _call: BurnCall;
 
   constructor(call: BurnCall) {
-    this._call = call
+    this._call = call;
   }
 
   get account(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get id(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 }
 
 export class BurnCall__Outputs {
-  _call: BurnCall
+  _call: BurnCall;
 
   constructor(call: BurnCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class BurnBatchCall extends ethereum.Call {
   get inputs(): BurnBatchCall__Inputs {
-    return new BurnBatchCall__Inputs(this)
+    return new BurnBatchCall__Inputs(this);
   }
 
   get outputs(): BurnBatchCall__Outputs {
-    return new BurnBatchCall__Outputs(this)
+    return new BurnBatchCall__Outputs(this);
   }
 }
 
 export class BurnBatchCall__Inputs {
-  _call: BurnBatchCall
+  _call: BurnBatchCall;
 
   constructor(call: BurnBatchCall) {
-    this._call = call
+    this._call = call;
   }
 
   get account(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get ids(): Array<BigInt> {
-    return this._call.inputValues[1].value.toBigIntArray()
+    return this._call.inputValues[1].value.toBigIntArray();
   }
 
   get amounts(): Array<BigInt> {
-    return this._call.inputValues[2].value.toBigIntArray()
+    return this._call.inputValues[2].value.toBigIntArray();
   }
 }
 
 export class BurnBatchCall__Outputs {
-  _call: BurnBatchCall
+  _call: BurnBatchCall;
 
   constructor(call: BurnBatchCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class GrantRoleCall extends ethereum.Call {
   get inputs(): GrantRoleCall__Inputs {
-    return new GrantRoleCall__Inputs(this)
+    return new GrantRoleCall__Inputs(this);
   }
 
   get outputs(): GrantRoleCall__Outputs {
-    return new GrantRoleCall__Outputs(this)
+    return new GrantRoleCall__Outputs(this);
   }
 }
 
 export class GrantRoleCall__Inputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class GrantRoleCall__Outputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class InitializeCall extends ethereum.Call {
   get inputs(): InitializeCall__Inputs {
-    return new InitializeCall__Inputs(this)
+    return new InitializeCall__Inputs(this);
   }
 
   get outputs(): InitializeCall__Outputs {
-    return new InitializeCall__Outputs(this)
+    return new InitializeCall__Outputs(this);
   }
 }
 
 export class InitializeCall__Inputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 
   get uri(): string {
-    return this._call.inputValues[0].value.toString()
+    return this._call.inputValues[0].value.toString();
   }
 }
 
 export class InitializeCall__Outputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class MintCall extends ethereum.Call {
   get inputs(): MintCall__Inputs {
-    return new MintCall__Inputs(this)
+    return new MintCall__Inputs(this);
   }
 
   get outputs(): MintCall__Outputs {
-    return new MintCall__Outputs(this)
+    return new MintCall__Outputs(this);
   }
 }
 
 export class MintCall__Inputs {
-  _call: MintCall
+  _call: MintCall;
 
   constructor(call: MintCall) {
-    this._call = call
+    this._call = call;
   }
 
   get to(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get id(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 
   get data(): Bytes {
-    return this._call.inputValues[3].value.toBytes()
+    return this._call.inputValues[3].value.toBytes();
   }
 }
 
 export class MintCall__Outputs {
-  _call: MintCall
+  _call: MintCall;
 
   constructor(call: MintCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class MintBatchCall extends ethereum.Call {
   get inputs(): MintBatchCall__Inputs {
-    return new MintBatchCall__Inputs(this)
+    return new MintBatchCall__Inputs(this);
   }
 
   get outputs(): MintBatchCall__Outputs {
-    return new MintBatchCall__Outputs(this)
+    return new MintBatchCall__Outputs(this);
   }
 }
 
 export class MintBatchCall__Inputs {
-  _call: MintBatchCall
+  _call: MintBatchCall;
 
   constructor(call: MintBatchCall) {
-    this._call = call
+    this._call = call;
   }
 
   get to(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get ids(): Array<BigInt> {
-    return this._call.inputValues[1].value.toBigIntArray()
+    return this._call.inputValues[1].value.toBigIntArray();
   }
 
   get amounts(): Array<BigInt> {
-    return this._call.inputValues[2].value.toBigIntArray()
+    return this._call.inputValues[2].value.toBigIntArray();
   }
 
   get data(): Bytes {
-    return this._call.inputValues[3].value.toBytes()
+    return this._call.inputValues[3].value.toBytes();
   }
 }
 
 export class MintBatchCall__Outputs {
-  _call: MintBatchCall
+  _call: MintBatchCall;
 
   constructor(call: MintBatchCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class PauseCall extends ethereum.Call {
   get inputs(): PauseCall__Inputs {
-    return new PauseCall__Inputs(this)
+    return new PauseCall__Inputs(this);
   }
 
   get outputs(): PauseCall__Outputs {
-    return new PauseCall__Outputs(this)
+    return new PauseCall__Outputs(this);
   }
 }
 
 export class PauseCall__Inputs {
-  _call: PauseCall
+  _call: PauseCall;
 
   constructor(call: PauseCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class PauseCall__Outputs {
-  _call: PauseCall
+  _call: PauseCall;
 
   constructor(call: PauseCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceRoleCall extends ethereum.Call {
   get inputs(): RenounceRoleCall__Inputs {
-    return new RenounceRoleCall__Inputs(this)
+    return new RenounceRoleCall__Inputs(this);
   }
 
   get outputs(): RenounceRoleCall__Outputs {
-    return new RenounceRoleCall__Outputs(this)
+    return new RenounceRoleCall__Outputs(this);
   }
 }
 
 export class RenounceRoleCall__Inputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RenounceRoleCall__Outputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RevokeRoleCall extends ethereum.Call {
   get inputs(): RevokeRoleCall__Inputs {
-    return new RevokeRoleCall__Inputs(this)
+    return new RevokeRoleCall__Inputs(this);
   }
 
   get outputs(): RevokeRoleCall__Outputs {
-    return new RevokeRoleCall__Outputs(this)
+    return new RevokeRoleCall__Outputs(this);
   }
 }
 
 export class RevokeRoleCall__Inputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RevokeRoleCall__Outputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class SafeBatchTransferFromCall extends ethereum.Call {
   get inputs(): SafeBatchTransferFromCall__Inputs {
-    return new SafeBatchTransferFromCall__Inputs(this)
+    return new SafeBatchTransferFromCall__Inputs(this);
   }
 
   get outputs(): SafeBatchTransferFromCall__Outputs {
-    return new SafeBatchTransferFromCall__Outputs(this)
+    return new SafeBatchTransferFromCall__Outputs(this);
   }
 }
 
 export class SafeBatchTransferFromCall__Inputs {
-  _call: SafeBatchTransferFromCall
+  _call: SafeBatchTransferFromCall;
 
   constructor(call: SafeBatchTransferFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get from(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get to(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get ids(): Array<BigInt> {
-    return this._call.inputValues[2].value.toBigIntArray()
+    return this._call.inputValues[2].value.toBigIntArray();
   }
 
   get amounts(): Array<BigInt> {
-    return this._call.inputValues[3].value.toBigIntArray()
+    return this._call.inputValues[3].value.toBigIntArray();
   }
 
   get data(): Bytes {
-    return this._call.inputValues[4].value.toBytes()
+    return this._call.inputValues[4].value.toBytes();
   }
 }
 
 export class SafeBatchTransferFromCall__Outputs {
-  _call: SafeBatchTransferFromCall
+  _call: SafeBatchTransferFromCall;
 
   constructor(call: SafeBatchTransferFromCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class SafeTransferFromCall extends ethereum.Call {
   get inputs(): SafeTransferFromCall__Inputs {
-    return new SafeTransferFromCall__Inputs(this)
+    return new SafeTransferFromCall__Inputs(this);
   }
 
   get outputs(): SafeTransferFromCall__Outputs {
-    return new SafeTransferFromCall__Outputs(this)
+    return new SafeTransferFromCall__Outputs(this);
   }
 }
 
 export class SafeTransferFromCall__Inputs {
-  _call: SafeTransferFromCall
+  _call: SafeTransferFromCall;
 
   constructor(call: SafeTransferFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get from(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get to(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get id(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[3].value.toBigInt()
+    return this._call.inputValues[3].value.toBigInt();
   }
 
   get data(): Bytes {
-    return this._call.inputValues[4].value.toBytes()
+    return this._call.inputValues[4].value.toBytes();
   }
 }
 
 export class SafeTransferFromCall__Outputs {
-  _call: SafeTransferFromCall
+  _call: SafeTransferFromCall;
 
   constructor(call: SafeTransferFromCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class SetApprovalForAllCall extends ethereum.Call {
   get inputs(): SetApprovalForAllCall__Inputs {
-    return new SetApprovalForAllCall__Inputs(this)
+    return new SetApprovalForAllCall__Inputs(this);
   }
 
   get outputs(): SetApprovalForAllCall__Outputs {
-    return new SetApprovalForAllCall__Outputs(this)
+    return new SetApprovalForAllCall__Outputs(this);
   }
 }
 
 export class SetApprovalForAllCall__Inputs {
-  _call: SetApprovalForAllCall
+  _call: SetApprovalForAllCall;
 
   constructor(call: SetApprovalForAllCall) {
-    this._call = call
+    this._call = call;
   }
 
   get operator(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get approved(): boolean {
-    return this._call.inputValues[1].value.toBoolean()
+    return this._call.inputValues[1].value.toBoolean();
   }
 }
 
 export class SetApprovalForAllCall__Outputs {
-  _call: SetApprovalForAllCall
+  _call: SetApprovalForAllCall;
 
   constructor(call: SetApprovalForAllCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class TransferOwnershipCall extends ethereum.Call {
   get inputs(): TransferOwnershipCall__Inputs {
-    return new TransferOwnershipCall__Inputs(this)
+    return new TransferOwnershipCall__Inputs(this);
   }
 
   get outputs(): TransferOwnershipCall__Outputs {
-    return new TransferOwnershipCall__Outputs(this)
+    return new TransferOwnershipCall__Outputs(this);
   }
 }
 
 export class TransferOwnershipCall__Inputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _newAdmin(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class TransferOwnershipCall__Outputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UnpauseCall extends ethereum.Call {
   get inputs(): UnpauseCall__Inputs {
-    return new UnpauseCall__Inputs(this)
+    return new UnpauseCall__Inputs(this);
   }
 
   get outputs(): UnpauseCall__Outputs {
-    return new UnpauseCall__Outputs(this)
+    return new UnpauseCall__Outputs(this);
   }
 }
 
 export class UnpauseCall__Inputs {
-  _call: UnpauseCall
+  _call: UnpauseCall;
 
   constructor(call: UnpauseCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UnpauseCall__Outputs {
-  _call: UnpauseCall
+  _call: UnpauseCall;
 
   constructor(call: UnpauseCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UpdateImplementationCall extends ethereum.Call {
   get inputs(): UpdateImplementationCall__Inputs {
-    return new UpdateImplementationCall__Inputs(this)
+    return new UpdateImplementationCall__Inputs(this);
   }
 
   get outputs(): UpdateImplementationCall__Outputs {
-    return new UpdateImplementationCall__Outputs(this)
+    return new UpdateImplementationCall__Outputs(this);
   }
 }
 
 export class UpdateImplementationCall__Inputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _newImplementation(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class UpdateImplementationCall__Outputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 }

--- a/subgraph/generated/ERC1155Controller/SeriesController.ts
+++ b/subgraph/generated/ERC1155Controller/SeriesController.ts
@@ -7,625 +7,625 @@ import {
   Entity,
   Bytes,
   Address,
-  BigInt,
-} from "@graphprotocol/graph-ts"
+  BigInt
+} from "@graphprotocol/graph-ts";
 
 export class CodeAddressUpdated extends ethereum.Event {
   get params(): CodeAddressUpdated__Params {
-    return new CodeAddressUpdated__Params(this)
+    return new CodeAddressUpdated__Params(this);
   }
 }
 
 export class CodeAddressUpdated__Params {
-  _event: CodeAddressUpdated
+  _event: CodeAddressUpdated;
 
   constructor(event: CodeAddressUpdated) {
-    this._event = event
+    this._event = event;
   }
 
   get newAddress(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class CollateralClaimed extends ethereum.Event {
   get params(): CollateralClaimed__Params {
-    return new CollateralClaimed__Params(this)
+    return new CollateralClaimed__Params(this);
   }
 }
 
 export class CollateralClaimed__Params {
-  _event: CollateralClaimed
+  _event: CollateralClaimed;
 
   constructor(event: CollateralClaimed) {
-    this._event = event
+    this._event = event;
   }
 
   get redeemer(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get optionTokenAmount(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 
   get wTokenTotalSupply(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 
   get bTokenTotalSupply(): BigInt {
-    return this._event.parameters[4].value.toBigInt()
+    return this._event.parameters[4].value.toBigInt();
   }
 
   get collateralAmount(): BigInt {
-    return this._event.parameters[5].value.toBigInt()
+    return this._event.parameters[5].value.toBigInt();
   }
 }
 
 export class ERC20VaultTransferIn extends ethereum.Event {
   get params(): ERC20VaultTransferIn__Params {
-    return new ERC20VaultTransferIn__Params(this)
+    return new ERC20VaultTransferIn__Params(this);
   }
 }
 
 export class ERC20VaultTransferIn__Params {
-  _event: ERC20VaultTransferIn
+  _event: ERC20VaultTransferIn;
 
   constructor(event: ERC20VaultTransferIn) {
-    this._event = event
+    this._event = event;
   }
 
   get sender(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get amount(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class ERC20VaultTransferOut extends ethereum.Event {
   get params(): ERC20VaultTransferOut__Params {
-    return new ERC20VaultTransferOut__Params(this)
+    return new ERC20VaultTransferOut__Params(this);
   }
 }
 
 export class ERC20VaultTransferOut__Params {
-  _event: ERC20VaultTransferOut
+  _event: ERC20VaultTransferOut;
 
   constructor(event: ERC20VaultTransferOut) {
-    this._event = event
+    this._event = event;
   }
 
   get recipient(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get amount(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class FeePaid extends ethereum.Event {
   get params(): FeePaid__Params {
-    return new FeePaid__Params(this)
+    return new FeePaid__Params(this);
   }
 }
 
 export class FeePaid__Params {
-  _event: FeePaid
+  _event: FeePaid;
 
   constructor(event: FeePaid) {
-    this._event = event
+    this._event = event;
   }
 
   get feeType(): i32 {
-    return this._event.parameters[0].value.toI32()
+    return this._event.parameters[0].value.toI32();
   }
 
   get token(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get value(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class OptionClosed extends ethereum.Event {
   get params(): OptionClosed__Params {
-    return new OptionClosed__Params(this)
+    return new OptionClosed__Params(this);
   }
 }
 
 export class OptionClosed__Params {
-  _event: OptionClosed
+  _event: OptionClosed;
 
   constructor(event: OptionClosed) {
-    this._event = event
+    this._event = event;
   }
 
   get redeemer(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get optionTokenAmount(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 
   get wTokenTotalSupply(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 
   get bTokenTotalSupply(): BigInt {
-    return this._event.parameters[4].value.toBigInt()
+    return this._event.parameters[4].value.toBigInt();
   }
 
   get collateralAmount(): BigInt {
-    return this._event.parameters[5].value.toBigInt()
+    return this._event.parameters[5].value.toBigInt();
   }
 }
 
 export class OptionExercised extends ethereum.Event {
   get params(): OptionExercised__Params {
-    return new OptionExercised__Params(this)
+    return new OptionExercised__Params(this);
   }
 }
 
 export class OptionExercised__Params {
-  _event: OptionExercised
+  _event: OptionExercised;
 
   constructor(event: OptionExercised) {
-    this._event = event
+    this._event = event;
   }
 
   get redeemer(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get optionTokenAmount(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 
   get wTokenTotalSupply(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 
   get bTokenTotalSupply(): BigInt {
-    return this._event.parameters[4].value.toBigInt()
+    return this._event.parameters[4].value.toBigInt();
   }
 
   get collateralAmount(): BigInt {
-    return this._event.parameters[5].value.toBigInt()
+    return this._event.parameters[5].value.toBigInt();
   }
 }
 
 export class OptionMinted extends ethereum.Event {
   get params(): OptionMinted__Params {
-    return new OptionMinted__Params(this)
+    return new OptionMinted__Params(this);
   }
 }
 
 export class OptionMinted__Params {
-  _event: OptionMinted
+  _event: OptionMinted;
 
   constructor(event: OptionMinted) {
-    this._event = event
+    this._event = event;
   }
 
   get minter(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get optionTokenAmount(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 
   get wTokenTotalSupply(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 
   get bTokenTotalSupply(): BigInt {
-    return this._event.parameters[4].value.toBigInt()
+    return this._event.parameters[4].value.toBigInt();
   }
 }
 
 export class Paused extends ethereum.Event {
   get params(): Paused__Params {
-    return new Paused__Params(this)
+    return new Paused__Params(this);
   }
 }
 
 export class Paused__Params {
-  _event: Paused
+  _event: Paused;
 
   constructor(event: Paused) {
-    this._event = event
+    this._event = event;
   }
 
   get account(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class RoleAdminChanged extends ethereum.Event {
   get params(): RoleAdminChanged__Params {
-    return new RoleAdminChanged__Params(this)
+    return new RoleAdminChanged__Params(this);
   }
 }
 
 export class RoleAdminChanged__Params {
-  _event: RoleAdminChanged
+  _event: RoleAdminChanged;
 
   constructor(event: RoleAdminChanged) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get previousAdminRole(): Bytes {
-    return this._event.parameters[1].value.toBytes()
+    return this._event.parameters[1].value.toBytes();
   }
 
   get newAdminRole(): Bytes {
-    return this._event.parameters[2].value.toBytes()
+    return this._event.parameters[2].value.toBytes();
   }
 }
 
 export class RoleGranted extends ethereum.Event {
   get params(): RoleGranted__Params {
-    return new RoleGranted__Params(this)
+    return new RoleGranted__Params(this);
   }
 }
 
 export class RoleGranted__Params {
-  _event: RoleGranted
+  _event: RoleGranted;
 
   constructor(event: RoleGranted) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class RoleRevoked extends ethereum.Event {
   get params(): RoleRevoked__Params {
-    return new RoleRevoked__Params(this)
+    return new RoleRevoked__Params(this);
   }
 }
 
 export class RoleRevoked__Params {
-  _event: RoleRevoked
+  _event: RoleRevoked;
 
   constructor(event: RoleRevoked) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class SeriesControllerInitialized extends ethereum.Event {
   get params(): SeriesControllerInitialized__Params {
-    return new SeriesControllerInitialized__Params(this)
+    return new SeriesControllerInitialized__Params(this);
   }
 }
 
 export class SeriesControllerInitialized__Params {
-  _event: SeriesControllerInitialized
+  _event: SeriesControllerInitialized;
 
   constructor(event: SeriesControllerInitialized) {
-    this._event = event
+    this._event = event;
   }
 
   get priceOracle(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get vault(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get erc1155Controller(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 
   get fees(): SeriesControllerInitializedFeesStruct {
-    return this._event.parameters[3].value.toTuple() as SeriesControllerInitializedFeesStruct
+    return this._event.parameters[3].value.toTuple() as SeriesControllerInitializedFeesStruct;
   }
 }
 
 export class SeriesControllerInitializedFeesStruct extends ethereum.Tuple {
   get feeReceiver(): Address {
-    return this[0].toAddress()
+    return this[0].toAddress();
   }
 
   get exerciseFeeBasisPoints(): i32 {
-    return this[1].toI32()
+    return this[1].toI32();
   }
 
   get closeFeeBasisPoints(): i32 {
-    return this[2].toI32()
+    return this[2].toI32();
   }
 
   get claimFeeBasisPoints(): i32 {
-    return this[3].toI32()
+    return this[3].toI32();
   }
 }
 
 export class SeriesCreated extends ethereum.Event {
   get params(): SeriesCreated__Params {
-    return new SeriesCreated__Params(this)
+    return new SeriesCreated__Params(this);
   }
 }
 
 export class SeriesCreated__Params {
-  _event: SeriesCreated
+  _event: SeriesCreated;
 
   constructor(event: SeriesCreated) {
-    this._event = event
+    this._event = event;
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[0].value.toBigInt()
+    return this._event.parameters[0].value.toBigInt();
   }
 
   get tokens(): SeriesCreatedTokensStruct {
-    return this._event.parameters[1].value.toTuple() as SeriesCreatedTokensStruct
+    return this._event.parameters[1].value.toTuple() as SeriesCreatedTokensStruct;
   }
 
   get restrictedMinters(): Array<Address> {
-    return this._event.parameters[2].value.toAddressArray()
+    return this._event.parameters[2].value.toAddressArray();
   }
 
   get strikePrice(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 
   get expirationDate(): BigInt {
-    return this._event.parameters[4].value.toBigInt()
+    return this._event.parameters[4].value.toBigInt();
   }
 
   get isPutOption(): boolean {
-    return this._event.parameters[5].value.toBoolean()
+    return this._event.parameters[5].value.toBoolean();
   }
 }
 
 export class SeriesCreatedTokensStruct extends ethereum.Tuple {
   get underlyingToken(): Address {
-    return this[0].toAddress()
+    return this[0].toAddress();
   }
 
   get priceToken(): Address {
-    return this[1].toAddress()
+    return this[1].toAddress();
   }
 
   get collateralToken(): Address {
-    return this[2].toAddress()
+    return this[2].toAddress();
   }
 }
 
 export class Unpaused extends ethereum.Event {
   get params(): Unpaused__Params {
-    return new Unpaused__Params(this)
+    return new Unpaused__Params(this);
   }
 }
 
 export class Unpaused__Params {
-  _event: Unpaused
+  _event: Unpaused;
 
   constructor(event: Unpaused) {
-    this._event = event
+    this._event = event;
   }
 
   get account(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class SeriesController__getClaimAmountResult {
-  value0: BigInt
-  value1: BigInt
+  value0: BigInt;
+  value1: BigInt;
 
   constructor(value0: BigInt, value1: BigInt) {
-    this.value0 = value0
-    this.value1 = value1
+    this.value0 = value0;
+    this.value1 = value1;
   }
 
   toMap(): TypedMap<string, ethereum.Value> {
-    let map = new TypedMap<string, ethereum.Value>()
-    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0))
-    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1))
-    return map
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    return map;
   }
 }
 
 export class SeriesController__getExerciseAmountResult {
-  value0: BigInt
-  value1: BigInt
+  value0: BigInt;
+  value1: BigInt;
 
   constructor(value0: BigInt, value1: BigInt) {
-    this.value0 = value0
-    this.value1 = value1
+    this.value0 = value0;
+    this.value1 = value1;
   }
 
   toMap(): TypedMap<string, ethereum.Value> {
-    let map = new TypedMap<string, ethereum.Value>()
-    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0))
-    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1))
-    return map
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    return map;
   }
 }
 
 export class SeriesController__getSettlementPriceResult {
-  value0: boolean
-  value1: BigInt
+  value0: boolean;
+  value1: BigInt;
 
   constructor(value0: boolean, value1: BigInt) {
-    this.value0 = value0
-    this.value1 = value1
+    this.value0 = value0;
+    this.value1 = value1;
   }
 
   toMap(): TypedMap<string, ethereum.Value> {
-    let map = new TypedMap<string, ethereum.Value>()
-    map.set("value0", ethereum.Value.fromBoolean(this.value0))
-    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1))
-    return map
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromBoolean(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    return map;
   }
 }
 
 export class SeriesController__seriesResultValue0Struct extends ethereum.Tuple {
   get expirationDate(): BigInt {
-    return this[0].toBigInt()
+    return this[0].toBigInt();
   }
 
   get isPutOption(): boolean {
-    return this[1].toBoolean()
+    return this[1].toBoolean();
   }
 
   get tokens(): SeriesController__seriesResultValue0TokensStruct {
-    return this[2].toTuple() as SeriesController__seriesResultValue0TokensStruct
+    return this[2].toTuple() as SeriesController__seriesResultValue0TokensStruct;
   }
 
   get strikePrice(): BigInt {
-    return this[3].toBigInt()
+    return this[3].toBigInt();
   }
 }
 
 export class SeriesController__seriesResultValue0TokensStruct extends ethereum.Tuple {
   get underlyingToken(): Address {
-    return this[0].toAddress()
+    return this[0].toAddress();
   }
 
   get priceToken(): Address {
-    return this[1].toAddress()
+    return this[1].toAddress();
   }
 
   get collateralToken(): Address {
-    return this[2].toAddress()
+    return this[2].toAddress();
   }
 }
 
 export class SeriesController extends ethereum.SmartContract {
   static bind(address: Address): SeriesController {
-    return new SeriesController("SeriesController", address)
+    return new SeriesController("SeriesController", address);
   }
 
   DEFAULT_ADMIN_ROLE(): Bytes {
     let result = super.call(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_DEFAULT_ADMIN_ROLE(): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   MINTER_ROLE(): Bytes {
-    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_MINTER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   PAUSER_ROLE(): Bytes {
-    let result = super.call("PAUSER_ROLE", "PAUSER_ROLE():(bytes32)", [])
+    let result = super.call("PAUSER_ROLE", "PAUSER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_PAUSER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("PAUSER_ROLE", "PAUSER_ROLE():(bytes32)", [])
+    let result = super.tryCall("PAUSER_ROLE", "PAUSER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   bTokenIndex(_seriesId: BigInt): BigInt {
     let result = super.call("bTokenIndex", "bTokenIndex(uint64):(uint256)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_bTokenIndex(_seriesId: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall("bTokenIndex", "bTokenIndex(uint64):(uint256)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   calculateFee(amount: BigInt, basisPoints: i32): BigInt {
@@ -634,1162 +634,1166 @@ export class SeriesController extends ethereum.SmartContract {
       "calculateFee(uint256,uint16):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(amount),
-        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(basisPoints)),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(basisPoints))
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_calculateFee(
     amount: BigInt,
-    basisPoints: i32,
+    basisPoints: i32
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "calculateFee",
       "calculateFee(uint256,uint16):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(amount),
-        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(basisPoints)),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(basisPoints))
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   claimFeeBasisPoints(_seriesId: BigInt): i32 {
     let result = super.call(
       "claimFeeBasisPoints",
       "claimFeeBasisPoints(uint64):(uint16)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_claimFeeBasisPoints(_seriesId: BigInt): ethereum.CallResult<i32> {
     let result = super.tryCall(
       "claimFeeBasisPoints",
       "claimFeeBasisPoints(uint64):(uint16)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   closeFeeBasisPoints(_seriesId: BigInt): i32 {
     let result = super.call(
       "closeFeeBasisPoints",
       "closeFeeBasisPoints(uint64):(uint16)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_closeFeeBasisPoints(_seriesId: BigInt): ethereum.CallResult<i32> {
     let result = super.tryCall(
       "closeFeeBasisPoints",
       "closeFeeBasisPoints(uint64):(uint16)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   collateralToken(_seriesId: BigInt): Address {
     let result = super.call(
       "collateralToken",
       "collateralToken(uint64):(address)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_collateralToken(_seriesId: BigInt): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "collateralToken",
       "collateralToken(uint64):(address)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   erc1155Controller(): Address {
     let result = super.call(
       "erc1155Controller",
       "erc1155Controller():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_erc1155Controller(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "erc1155Controller",
       "erc1155Controller():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   exerciseFeeBasisPoints(_seriesId: BigInt): i32 {
     let result = super.call(
       "exerciseFeeBasisPoints",
       "exerciseFeeBasisPoints(uint64):(uint16)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_exerciseFeeBasisPoints(_seriesId: BigInt): ethereum.CallResult<i32> {
     let result = super.tryCall(
       "exerciseFeeBasisPoints",
       "exerciseFeeBasisPoints(uint64):(uint16)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   expirationDate(_seriesId: BigInt): BigInt {
     let result = super.call(
       "expirationDate",
       "expirationDate(uint64):(uint40)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_expirationDate(_seriesId: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "expirationDate",
       "expirationDate(uint64):(uint40)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getClaimAmount(
     _seriesId: BigInt,
-    _wTokenAmount: BigInt,
+    _wTokenAmount: BigInt
   ): SeriesController__getClaimAmountResult {
     let result = super.call(
       "getClaimAmount",
       "getClaimAmount(uint64,uint256):(uint256,uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(_seriesId),
-        ethereum.Value.fromUnsignedBigInt(_wTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(_wTokenAmount)
+      ]
+    );
 
     return new SeriesController__getClaimAmountResult(
       result[0].toBigInt(),
-      result[1].toBigInt(),
-    )
+      result[1].toBigInt()
+    );
   }
 
   try_getClaimAmount(
     _seriesId: BigInt,
-    _wTokenAmount: BigInt,
+    _wTokenAmount: BigInt
   ): ethereum.CallResult<SeriesController__getClaimAmountResult> {
     let result = super.tryCall(
       "getClaimAmount",
       "getClaimAmount(uint64,uint256):(uint256,uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(_seriesId),
-        ethereum.Value.fromUnsignedBigInt(_wTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(_wTokenAmount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
+    let value = result.value;
     return ethereum.CallResult.fromValue(
       new SeriesController__getClaimAmountResult(
         value[0].toBigInt(),
-        value[1].toBigInt(),
-      ),
-    )
+        value[1].toBigInt()
+      )
+    );
   }
 
   getCollateralPerOptionToken(
     _seriesId: BigInt,
-    _optionTokenAmount: BigInt,
+    _optionTokenAmount: BigInt
   ): BigInt {
     let result = super.call(
       "getCollateralPerOptionToken",
       "getCollateralPerOptionToken(uint64,uint256):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(_seriesId),
-        ethereum.Value.fromUnsignedBigInt(_optionTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(_optionTokenAmount)
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_getCollateralPerOptionToken(
     _seriesId: BigInt,
-    _optionTokenAmount: BigInt,
+    _optionTokenAmount: BigInt
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "getCollateralPerOptionToken",
       "getCollateralPerOptionToken(uint64,uint256):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(_seriesId),
-        ethereum.Value.fromUnsignedBigInt(_optionTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(_optionTokenAmount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getExerciseAmount(
     _seriesId: BigInt,
-    _bTokenAmount: BigInt,
+    _bTokenAmount: BigInt
   ): SeriesController__getExerciseAmountResult {
     let result = super.call(
       "getExerciseAmount",
       "getExerciseAmount(uint64,uint256):(uint256,uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(_seriesId),
-        ethereum.Value.fromUnsignedBigInt(_bTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(_bTokenAmount)
+      ]
+    );
 
     return new SeriesController__getExerciseAmountResult(
       result[0].toBigInt(),
-      result[1].toBigInt(),
-    )
+      result[1].toBigInt()
+    );
   }
 
   try_getExerciseAmount(
     _seriesId: BigInt,
-    _bTokenAmount: BigInt,
+    _bTokenAmount: BigInt
   ): ethereum.CallResult<SeriesController__getExerciseAmountResult> {
     let result = super.tryCall(
       "getExerciseAmount",
       "getExerciseAmount(uint64,uint256):(uint256,uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(_seriesId),
-        ethereum.Value.fromUnsignedBigInt(_bTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(_bTokenAmount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
+    let value = result.value;
     return ethereum.CallResult.fromValue(
       new SeriesController__getExerciseAmountResult(
         value[0].toBigInt(),
-        value[1].toBigInt(),
-      ),
-    )
+        value[1].toBigInt()
+      )
+    );
   }
 
   getLogicAddress(): Address {
     let result = super.call(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_getLogicAddress(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   getRoleAdmin(role: Bytes): Bytes {
     let result = super.call("getRoleAdmin", "getRoleAdmin(bytes32):(bytes32)", [
-      ethereum.Value.fromFixedBytes(role),
-    ])
+      ethereum.Value.fromFixedBytes(role)
+    ]);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_getRoleAdmin(role: Bytes): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "getRoleAdmin",
       "getRoleAdmin(bytes32):(bytes32)",
-      [ethereum.Value.fromFixedBytes(role)],
-    )
+      [ethereum.Value.fromFixedBytes(role)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   getSeriesERC20Balance(_seriesId: BigInt): BigInt {
     let result = super.call(
       "getSeriesERC20Balance",
       "getSeriesERC20Balance(uint64):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_getSeriesERC20Balance(_seriesId: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "getSeriesERC20Balance",
       "getSeriesERC20Balance(uint64):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getSettlementPrice(
-    _seriesId: BigInt,
+    _seriesId: BigInt
   ): SeriesController__getSettlementPriceResult {
     let result = super.call(
       "getSettlementPrice",
       "getSettlementPrice(uint64):(bool,uint256)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
     return new SeriesController__getSettlementPriceResult(
       result[0].toBoolean(),
-      result[1].toBigInt(),
-    )
+      result[1].toBigInt()
+    );
   }
 
   try_getSettlementPrice(
-    _seriesId: BigInt,
+    _seriesId: BigInt
   ): ethereum.CallResult<SeriesController__getSettlementPriceResult> {
     let result = super.tryCall(
       "getSettlementPrice",
       "getSettlementPrice(uint64):(bool,uint256)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
+    let value = result.value;
     return ethereum.CallResult.fromValue(
       new SeriesController__getSettlementPriceResult(
         value[0].toBoolean(),
-        value[1].toBigInt(),
-      ),
-    )
+        value[1].toBigInt()
+      )
+    );
   }
 
   hasRole(role: Bytes, account: Address): boolean {
     let result = super.call("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_hasRole(role: Bytes, account: Address): ethereum.CallResult<boolean> {
     let result = super.tryCall("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   isPutOption(_seriesId: BigInt): boolean {
     let result = super.call("isPutOption", "isPutOption(uint64):(bool)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_isPutOption(_seriesId: BigInt): ethereum.CallResult<boolean> {
     let result = super.tryCall("isPutOption", "isPutOption(uint64):(bool)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   latestIndex(): BigInt {
-    let result = super.call("latestIndex", "latestIndex():(uint64)", [])
+    let result = super.call("latestIndex", "latestIndex():(uint64)", []);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_latestIndex(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall("latestIndex", "latestIndex():(uint64)", [])
+    let result = super.tryCall("latestIndex", "latestIndex():(uint64)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   paused(): boolean {
-    let result = super.call("paused", "paused():(bool)", [])
+    let result = super.call("paused", "paused():(bool)", []);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_paused(): ethereum.CallResult<boolean> {
-    let result = super.tryCall("paused", "paused():(bool)", [])
+    let result = super.tryCall("paused", "paused():(bool)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   priceDecimals(): i32 {
-    let result = super.call("priceDecimals", "priceDecimals():(uint8)", [])
+    let result = super.call("priceDecimals", "priceDecimals():(uint8)", []);
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_priceDecimals(): ethereum.CallResult<i32> {
-    let result = super.tryCall("priceDecimals", "priceDecimals():(uint8)", [])
+    let result = super.tryCall("priceDecimals", "priceDecimals():(uint8)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   priceToken(_seriesId: BigInt): Address {
     let result = super.call("priceToken", "priceToken(uint64):(address)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_priceToken(_seriesId: BigInt): ethereum.CallResult<Address> {
     let result = super.tryCall("priceToken", "priceToken(uint64):(address)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   proxiableUUID(): Bytes {
-    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_proxiableUUID(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.tryCall(
+      "proxiableUUID",
+      "proxiableUUID():(bytes32)",
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   series(seriesId: BigInt): SeriesController__seriesResultValue0Struct {
     let result = super.call(
       "series",
       "series(uint256):((uint40,bool,(address,address,address),uint256))",
-      [ethereum.Value.fromUnsignedBigInt(seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(seriesId)]
+    );
 
-    return result[0].toTuple() as SeriesController__seriesResultValue0Struct
+    return result[0].toTuple() as SeriesController__seriesResultValue0Struct;
   }
 
   try_series(
-    seriesId: BigInt,
+    seriesId: BigInt
   ): ethereum.CallResult<SeriesController__seriesResultValue0Struct> {
     let result = super.tryCall(
       "series",
       "series(uint256):((uint40,bool,(address,address,address),uint256))",
-      [ethereum.Value.fromUnsignedBigInt(seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
+    let value = result.value;
     return ethereum.CallResult.fromValue(
-      value[0].toTuple() as SeriesController__seriesResultValue0Struct,
-    )
+      value[0].toTuple() as SeriesController__seriesResultValue0Struct
+    );
   }
 
   seriesName(_seriesId: BigInt): string {
     let result = super.call("seriesName", "seriesName(uint64):(string)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toString()
+    return result[0].toString();
   }
 
   try_seriesName(_seriesId: BigInt): ethereum.CallResult<string> {
     let result = super.tryCall("seriesName", "seriesName(uint64):(string)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toString())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toString());
   }
 
   state(_seriesId: BigInt): i32 {
     let result = super.call("state", "state(uint64):(uint8)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_state(_seriesId: BigInt): ethereum.CallResult<i32> {
     let result = super.tryCall("state", "state(uint64):(uint8)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   strikePrice(_seriesId: BigInt): BigInt {
     let result = super.call("strikePrice", "strikePrice(uint64):(uint256)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_strikePrice(_seriesId: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall("strikePrice", "strikePrice(uint64):(uint256)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   supportsInterface(interfaceId: Bytes): boolean {
     let result = super.call(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_supportsInterface(interfaceId: Bytes): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   underlyingToken(_seriesId: BigInt): Address {
     let result = super.call(
       "underlyingToken",
       "underlyingToken(uint64):(address)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_underlyingToken(_seriesId: BigInt): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "underlyingToken",
       "underlyingToken(uint64):(address)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   wTokenIndex(_seriesId: BigInt): BigInt {
     let result = super.call("wTokenIndex", "wTokenIndex(uint64):(uint256)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_wTokenIndex(_seriesId: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall("wTokenIndex", "wTokenIndex(uint64):(uint256)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 }
 
 export class __SeriesController_initCall extends ethereum.Call {
   get inputs(): __SeriesController_initCall__Inputs {
-    return new __SeriesController_initCall__Inputs(this)
+    return new __SeriesController_initCall__Inputs(this);
   }
 
   get outputs(): __SeriesController_initCall__Outputs {
-    return new __SeriesController_initCall__Outputs(this)
+    return new __SeriesController_initCall__Outputs(this);
   }
 }
 
 export class __SeriesController_initCall__Inputs {
-  _call: __SeriesController_initCall
+  _call: __SeriesController_initCall;
 
   constructor(call: __SeriesController_initCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _priceOracle(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get _vault(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get _erc1155Controller(): Address {
-    return this._call.inputValues[2].value.toAddress()
+    return this._call.inputValues[2].value.toAddress();
   }
 
   get _fees(): __SeriesController_initCall_feesStruct {
-    return this._call.inputValues[3].value.toTuple() as __SeriesController_initCall_feesStruct
+    return this._call.inputValues[3].value.toTuple() as __SeriesController_initCall_feesStruct;
   }
 }
 
 export class __SeriesController_initCall__Outputs {
-  _call: __SeriesController_initCall
+  _call: __SeriesController_initCall;
 
   constructor(call: __SeriesController_initCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class __SeriesController_initCall_feesStruct extends ethereum.Tuple {
   get feeReceiver(): Address {
-    return this[0].toAddress()
+    return this[0].toAddress();
   }
 
   get exerciseFeeBasisPoints(): i32 {
-    return this[1].toI32()
+    return this[1].toI32();
   }
 
   get closeFeeBasisPoints(): i32 {
-    return this[2].toI32()
+    return this[2].toI32();
   }
 
   get claimFeeBasisPoints(): i32 {
-    return this[3].toI32()
+    return this[3].toI32();
   }
 }
 
 export class ClaimCollateralCall extends ethereum.Call {
   get inputs(): ClaimCollateralCall__Inputs {
-    return new ClaimCollateralCall__Inputs(this)
+    return new ClaimCollateralCall__Inputs(this);
   }
 
   get outputs(): ClaimCollateralCall__Outputs {
-    return new ClaimCollateralCall__Outputs(this)
+    return new ClaimCollateralCall__Outputs(this);
   }
 }
 
 export class ClaimCollateralCall__Inputs {
-  _call: ClaimCollateralCall
+  _call: ClaimCollateralCall;
 
   constructor(call: ClaimCollateralCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get _wTokenAmount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class ClaimCollateralCall__Outputs {
-  _call: ClaimCollateralCall
+  _call: ClaimCollateralCall;
 
   constructor(call: ClaimCollateralCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class ClosePositionCall extends ethereum.Call {
   get inputs(): ClosePositionCall__Inputs {
-    return new ClosePositionCall__Inputs(this)
+    return new ClosePositionCall__Inputs(this);
   }
 
   get outputs(): ClosePositionCall__Outputs {
-    return new ClosePositionCall__Outputs(this)
+    return new ClosePositionCall__Outputs(this);
   }
 }
 
 export class ClosePositionCall__Inputs {
-  _call: ClosePositionCall
+  _call: ClosePositionCall;
 
   constructor(call: ClosePositionCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get _optionTokenAmount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class ClosePositionCall__Outputs {
-  _call: ClosePositionCall
+  _call: ClosePositionCall;
 
   constructor(call: ClosePositionCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class CreateSeriesCall extends ethereum.Call {
   get inputs(): CreateSeriesCall__Inputs {
-    return new CreateSeriesCall__Inputs(this)
+    return new CreateSeriesCall__Inputs(this);
   }
 
   get outputs(): CreateSeriesCall__Outputs {
-    return new CreateSeriesCall__Outputs(this)
+    return new CreateSeriesCall__Outputs(this);
   }
 }
 
 export class CreateSeriesCall__Inputs {
-  _call: CreateSeriesCall
+  _call: CreateSeriesCall;
 
   constructor(call: CreateSeriesCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _tokens(): CreateSeriesCall_tokensStruct {
-    return this._call.inputValues[0].value.toTuple() as CreateSeriesCall_tokensStruct
+    return this._call.inputValues[0].value.toTuple() as CreateSeriesCall_tokensStruct;
   }
 
   get _strikePrices(): Array<BigInt> {
-    return this._call.inputValues[1].value.toBigIntArray()
+    return this._call.inputValues[1].value.toBigIntArray();
   }
 
   get _expirationDates(): Array<BigInt> {
-    return this._call.inputValues[2].value.toBigIntArray()
+    return this._call.inputValues[2].value.toBigIntArray();
   }
 
   get _restrictedMinters(): Array<Address> {
-    return this._call.inputValues[3].value.toAddressArray()
+    return this._call.inputValues[3].value.toAddressArray();
   }
 
   get _isPutOption(): boolean {
-    return this._call.inputValues[4].value.toBoolean()
+    return this._call.inputValues[4].value.toBoolean();
   }
 }
 
 export class CreateSeriesCall__Outputs {
-  _call: CreateSeriesCall
+  _call: CreateSeriesCall;
 
   constructor(call: CreateSeriesCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class CreateSeriesCall_tokensStruct extends ethereum.Tuple {
   get underlyingToken(): Address {
-    return this[0].toAddress()
+    return this[0].toAddress();
   }
 
   get priceToken(): Address {
-    return this[1].toAddress()
+    return this[1].toAddress();
   }
 
   get collateralToken(): Address {
-    return this[2].toAddress()
+    return this[2].toAddress();
   }
 }
 
 export class ExerciseOptionCall extends ethereum.Call {
   get inputs(): ExerciseOptionCall__Inputs {
-    return new ExerciseOptionCall__Inputs(this)
+    return new ExerciseOptionCall__Inputs(this);
   }
 
   get outputs(): ExerciseOptionCall__Outputs {
-    return new ExerciseOptionCall__Outputs(this)
+    return new ExerciseOptionCall__Outputs(this);
   }
 }
 
 export class ExerciseOptionCall__Inputs {
-  _call: ExerciseOptionCall
+  _call: ExerciseOptionCall;
 
   constructor(call: ExerciseOptionCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get _bTokenAmount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 
   get _revertOtm(): boolean {
-    return this._call.inputValues[2].value.toBoolean()
+    return this._call.inputValues[2].value.toBoolean();
   }
 }
 
 export class ExerciseOptionCall__Outputs {
-  _call: ExerciseOptionCall
+  _call: ExerciseOptionCall;
 
   constructor(call: ExerciseOptionCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class GrantRoleCall extends ethereum.Call {
   get inputs(): GrantRoleCall__Inputs {
-    return new GrantRoleCall__Inputs(this)
+    return new GrantRoleCall__Inputs(this);
   }
 
   get outputs(): GrantRoleCall__Outputs {
-    return new GrantRoleCall__Outputs(this)
+    return new GrantRoleCall__Outputs(this);
   }
 }
 
 export class GrantRoleCall__Inputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class GrantRoleCall__Outputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class MintOptionsCall extends ethereum.Call {
   get inputs(): MintOptionsCall__Inputs {
-    return new MintOptionsCall__Inputs(this)
+    return new MintOptionsCall__Inputs(this);
   }
 
   get outputs(): MintOptionsCall__Outputs {
-    return new MintOptionsCall__Outputs(this)
+    return new MintOptionsCall__Outputs(this);
   }
 }
 
 export class MintOptionsCall__Inputs {
-  _call: MintOptionsCall
+  _call: MintOptionsCall;
 
   constructor(call: MintOptionsCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get _optionTokenAmount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class MintOptionsCall__Outputs {
-  _call: MintOptionsCall
+  _call: MintOptionsCall;
 
   constructor(call: MintOptionsCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class PauseCall extends ethereum.Call {
   get inputs(): PauseCall__Inputs {
-    return new PauseCall__Inputs(this)
+    return new PauseCall__Inputs(this);
   }
 
   get outputs(): PauseCall__Outputs {
-    return new PauseCall__Outputs(this)
+    return new PauseCall__Outputs(this);
   }
 }
 
 export class PauseCall__Inputs {
-  _call: PauseCall
+  _call: PauseCall;
 
   constructor(call: PauseCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class PauseCall__Outputs {
-  _call: PauseCall
+  _call: PauseCall;
 
   constructor(call: PauseCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceRoleCall extends ethereum.Call {
   get inputs(): RenounceRoleCall__Inputs {
-    return new RenounceRoleCall__Inputs(this)
+    return new RenounceRoleCall__Inputs(this);
   }
 
   get outputs(): RenounceRoleCall__Outputs {
-    return new RenounceRoleCall__Outputs(this)
+    return new RenounceRoleCall__Outputs(this);
   }
 }
 
 export class RenounceRoleCall__Inputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RenounceRoleCall__Outputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RevokeRoleCall extends ethereum.Call {
   get inputs(): RevokeRoleCall__Inputs {
-    return new RevokeRoleCall__Inputs(this)
+    return new RevokeRoleCall__Inputs(this);
   }
 
   get outputs(): RevokeRoleCall__Outputs {
-    return new RevokeRoleCall__Outputs(this)
+    return new RevokeRoleCall__Outputs(this);
   }
 }
 
 export class RevokeRoleCall__Inputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RevokeRoleCall__Outputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class SetPriceOracleCall extends ethereum.Call {
   get inputs(): SetPriceOracleCall__Inputs {
-    return new SetPriceOracleCall__Inputs(this)
+    return new SetPriceOracleCall__Inputs(this);
   }
 
   get outputs(): SetPriceOracleCall__Outputs {
-    return new SetPriceOracleCall__Outputs(this)
+    return new SetPriceOracleCall__Outputs(this);
   }
 }
 
 export class SetPriceOracleCall__Inputs {
-  _call: SetPriceOracleCall
+  _call: SetPriceOracleCall;
 
   constructor(call: SetPriceOracleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _priceOracle(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class SetPriceOracleCall__Outputs {
-  _call: SetPriceOracleCall
+  _call: SetPriceOracleCall;
 
   constructor(call: SetPriceOracleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class TransferOwnershipCall extends ethereum.Call {
   get inputs(): TransferOwnershipCall__Inputs {
-    return new TransferOwnershipCall__Inputs(this)
+    return new TransferOwnershipCall__Inputs(this);
   }
 
   get outputs(): TransferOwnershipCall__Outputs {
-    return new TransferOwnershipCall__Outputs(this)
+    return new TransferOwnershipCall__Outputs(this);
   }
 }
 
 export class TransferOwnershipCall__Inputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _newAdmin(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class TransferOwnershipCall__Outputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UnpauseCall extends ethereum.Call {
   get inputs(): UnpauseCall__Inputs {
-    return new UnpauseCall__Inputs(this)
+    return new UnpauseCall__Inputs(this);
   }
 
   get outputs(): UnpauseCall__Outputs {
-    return new UnpauseCall__Outputs(this)
+    return new UnpauseCall__Outputs(this);
   }
 }
 
 export class UnpauseCall__Inputs {
-  _call: UnpauseCall
+  _call: UnpauseCall;
 
   constructor(call: UnpauseCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UnpauseCall__Outputs {
-  _call: UnpauseCall
+  _call: UnpauseCall;
 
   constructor(call: UnpauseCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UpdateImplementationCall extends ethereum.Call {
   get inputs(): UpdateImplementationCall__Inputs {
-    return new UpdateImplementationCall__Inputs(this)
+    return new UpdateImplementationCall__Inputs(this);
   }
 
   get outputs(): UpdateImplementationCall__Outputs {
-    return new UpdateImplementationCall__Outputs(this)
+    return new UpdateImplementationCall__Outputs(this);
   }
 }
 
 export class UpdateImplementationCall__Inputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _newImplementation(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class UpdateImplementationCall__Outputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 }

--- a/subgraph/generated/ERC1155Controller/SimpleToken.ts
+++ b/subgraph/generated/ERC1155Controller/SimpleToken.ts
@@ -7,273 +7,273 @@ import {
   Entity,
   Bytes,
   Address,
-  BigInt,
-} from "@graphprotocol/graph-ts"
+  BigInt
+} from "@graphprotocol/graph-ts";
 
 export class Approval extends ethereum.Event {
   get params(): Approval__Params {
-    return new Approval__Params(this)
+    return new Approval__Params(this);
   }
 }
 
 export class Approval__Params {
-  _event: Approval
+  _event: Approval;
 
   constructor(event: Approval) {
-    this._event = event
+    this._event = event;
   }
 
   get owner(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get spender(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get value(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class RoleAdminChanged extends ethereum.Event {
   get params(): RoleAdminChanged__Params {
-    return new RoleAdminChanged__Params(this)
+    return new RoleAdminChanged__Params(this);
   }
 }
 
 export class RoleAdminChanged__Params {
-  _event: RoleAdminChanged
+  _event: RoleAdminChanged;
 
   constructor(event: RoleAdminChanged) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get previousAdminRole(): Bytes {
-    return this._event.parameters[1].value.toBytes()
+    return this._event.parameters[1].value.toBytes();
   }
 
   get newAdminRole(): Bytes {
-    return this._event.parameters[2].value.toBytes()
+    return this._event.parameters[2].value.toBytes();
   }
 }
 
 export class RoleGranted extends ethereum.Event {
   get params(): RoleGranted__Params {
-    return new RoleGranted__Params(this)
+    return new RoleGranted__Params(this);
   }
 }
 
 export class RoleGranted__Params {
-  _event: RoleGranted
+  _event: RoleGranted;
 
   constructor(event: RoleGranted) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class RoleRevoked extends ethereum.Event {
   get params(): RoleRevoked__Params {
-    return new RoleRevoked__Params(this)
+    return new RoleRevoked__Params(this);
   }
 }
 
 export class RoleRevoked__Params {
-  _event: RoleRevoked
+  _event: RoleRevoked;
 
   constructor(event: RoleRevoked) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class Transfer extends ethereum.Event {
   get params(): Transfer__Params {
-    return new Transfer__Params(this)
+    return new Transfer__Params(this);
   }
 }
 
 export class Transfer__Params {
-  _event: Transfer
+  _event: Transfer;
 
   constructor(event: Transfer) {
-    this._event = event
+    this._event = event;
   }
 
   get from(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get to(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get value(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class SimpleToken extends ethereum.SmartContract {
   static bind(address: Address): SimpleToken {
-    return new SimpleToken("SimpleToken", address)
+    return new SimpleToken("SimpleToken", address);
   }
 
   BURNER_ROLE(): Bytes {
-    let result = super.call("BURNER_ROLE", "BURNER_ROLE():(bytes32)", [])
+    let result = super.call("BURNER_ROLE", "BURNER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_BURNER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("BURNER_ROLE", "BURNER_ROLE():(bytes32)", [])
+    let result = super.tryCall("BURNER_ROLE", "BURNER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   DEFAULT_ADMIN_ROLE(): Bytes {
     let result = super.call(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_DEFAULT_ADMIN_ROLE(): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   MINTER_ROLE(): Bytes {
-    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_MINTER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   allowance(owner: Address, spender: Address): BigInt {
     let result = super.call(
       "allowance",
       "allowance(address,address):(uint256)",
-      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)],
-    )
+      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_allowance(owner: Address, spender: Address): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "allowance",
       "allowance(address,address):(uint256)",
-      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)],
-    )
+      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   approve(spender: Address, amount: BigInt): boolean {
     let result = super.call("approve", "approve(address,uint256):(bool)", [
       ethereum.Value.fromAddress(spender),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_approve(spender: Address, amount: BigInt): ethereum.CallResult<boolean> {
     let result = super.tryCall("approve", "approve(address,uint256):(bool)", [
       ethereum.Value.fromAddress(spender),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   balanceOf(account: Address): BigInt {
     let result = super.call("balanceOf", "balanceOf(address):(uint256)", [
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_balanceOf(account: Address): ethereum.CallResult<BigInt> {
     let result = super.tryCall("balanceOf", "balanceOf(address):(uint256)", [
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   decimals(): i32 {
-    let result = super.call("decimals", "decimals():(uint8)", [])
+    let result = super.call("decimals", "decimals():(uint8)", []);
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_decimals(): ethereum.CallResult<i32> {
-    let result = super.tryCall("decimals", "decimals():(uint8)", [])
+    let result = super.tryCall("decimals", "decimals():(uint8)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   decreaseAllowance(spender: Address, subtractedValue: BigInt): boolean {
@@ -282,72 +282,72 @@ export class SimpleToken extends ethereum.SmartContract {
       "decreaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(subtractedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(subtractedValue)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_decreaseAllowance(
     spender: Address,
-    subtractedValue: BigInt,
+    subtractedValue: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "decreaseAllowance",
       "decreaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(subtractedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(subtractedValue)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   getRoleAdmin(role: Bytes): Bytes {
     let result = super.call("getRoleAdmin", "getRoleAdmin(bytes32):(bytes32)", [
-      ethereum.Value.fromFixedBytes(role),
-    ])
+      ethereum.Value.fromFixedBytes(role)
+    ]);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_getRoleAdmin(role: Bytes): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "getRoleAdmin",
       "getRoleAdmin(bytes32):(bytes32)",
-      [ethereum.Value.fromFixedBytes(role)],
-    )
+      [ethereum.Value.fromFixedBytes(role)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   hasRole(role: Bytes, account: Address): boolean {
     let result = super.call("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_hasRole(role: Bytes, account: Address): ethereum.CallResult<boolean> {
     let result = super.tryCall("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   increaseAllowance(spender: Address, addedValue: BigInt): boolean {
@@ -356,122 +356,122 @@ export class SimpleToken extends ethereum.SmartContract {
       "increaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(addedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(addedValue)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_increaseAllowance(
     spender: Address,
-    addedValue: BigInt,
+    addedValue: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "increaseAllowance",
       "increaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(addedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(addedValue)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   name(): string {
-    let result = super.call("name", "name():(string)", [])
+    let result = super.call("name", "name():(string)", []);
 
-    return result[0].toString()
+    return result[0].toString();
   }
 
   try_name(): ethereum.CallResult<string> {
-    let result = super.tryCall("name", "name():(string)", [])
+    let result = super.tryCall("name", "name():(string)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toString())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toString());
   }
 
   supportsInterface(interfaceId: Bytes): boolean {
     let result = super.call(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_supportsInterface(interfaceId: Bytes): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   symbol(): string {
-    let result = super.call("symbol", "symbol():(string)", [])
+    let result = super.call("symbol", "symbol():(string)", []);
 
-    return result[0].toString()
+    return result[0].toString();
   }
 
   try_symbol(): ethereum.CallResult<string> {
-    let result = super.tryCall("symbol", "symbol():(string)", [])
+    let result = super.tryCall("symbol", "symbol():(string)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toString())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toString());
   }
 
   totalSupply(): BigInt {
-    let result = super.call("totalSupply", "totalSupply():(uint256)", [])
+    let result = super.call("totalSupply", "totalSupply():(uint256)", []);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_totalSupply(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall("totalSupply", "totalSupply():(uint256)", [])
+    let result = super.tryCall("totalSupply", "totalSupply():(uint256)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   transfer(recipient: Address, amount: BigInt): boolean {
     let result = super.call("transfer", "transfer(address,uint256):(bool)", [
       ethereum.Value.fromAddress(recipient),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_transfer(
     recipient: Address,
-    amount: BigInt,
+    amount: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall("transfer", "transfer(address,uint256):(bool)", [
       ethereum.Value.fromAddress(recipient),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   transferFrom(sender: Address, recipient: Address, amount: BigInt): boolean {
@@ -481,17 +481,17 @@ export class SimpleToken extends ethereum.SmartContract {
       [
         ethereum.Value.fromAddress(sender),
         ethereum.Value.fromAddress(recipient),
-        ethereum.Value.fromUnsignedBigInt(amount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(amount)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_transferFrom(
     sender: Address,
     recipient: Address,
-    amount: BigInt,
+    amount: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "transferFrom",
@@ -499,479 +499,479 @@ export class SimpleToken extends ethereum.SmartContract {
       [
         ethereum.Value.fromAddress(sender),
         ethereum.Value.fromAddress(recipient),
-        ethereum.Value.fromUnsignedBigInt(amount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(amount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 }
 
 export class ApproveCall extends ethereum.Call {
   get inputs(): ApproveCall__Inputs {
-    return new ApproveCall__Inputs(this)
+    return new ApproveCall__Inputs(this);
   }
 
   get outputs(): ApproveCall__Outputs {
-    return new ApproveCall__Outputs(this)
+    return new ApproveCall__Outputs(this);
   }
 }
 
 export class ApproveCall__Inputs {
-  _call: ApproveCall
+  _call: ApproveCall;
 
   constructor(call: ApproveCall) {
-    this._call = call
+    this._call = call;
   }
 
   get spender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class ApproveCall__Outputs {
-  _call: ApproveCall
+  _call: ApproveCall;
 
   constructor(call: ApproveCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class BurnCall extends ethereum.Call {
   get inputs(): BurnCall__Inputs {
-    return new BurnCall__Inputs(this)
+    return new BurnCall__Inputs(this);
   }
 
   get outputs(): BurnCall__Outputs {
-    return new BurnCall__Outputs(this)
+    return new BurnCall__Outputs(this);
   }
 }
 
 export class BurnCall__Inputs {
-  _call: BurnCall
+  _call: BurnCall;
 
   constructor(call: BurnCall) {
-    this._call = call
+    this._call = call;
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 }
 
 export class BurnCall__Outputs {
-  _call: BurnCall
+  _call: BurnCall;
 
   constructor(call: BurnCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class Burn1Call extends ethereum.Call {
   get inputs(): Burn1Call__Inputs {
-    return new Burn1Call__Inputs(this)
+    return new Burn1Call__Inputs(this);
   }
 
   get outputs(): Burn1Call__Outputs {
-    return new Burn1Call__Outputs(this)
+    return new Burn1Call__Outputs(this);
   }
 }
 
 export class Burn1Call__Inputs {
-  _call: Burn1Call
+  _call: Burn1Call;
 
   constructor(call: Burn1Call) {
-    this._call = call
+    this._call = call;
   }
 
   get account(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class Burn1Call__Outputs {
-  _call: Burn1Call
+  _call: Burn1Call;
 
   constructor(call: Burn1Call) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class BurnFromCall extends ethereum.Call {
   get inputs(): BurnFromCall__Inputs {
-    return new BurnFromCall__Inputs(this)
+    return new BurnFromCall__Inputs(this);
   }
 
   get outputs(): BurnFromCall__Outputs {
-    return new BurnFromCall__Outputs(this)
+    return new BurnFromCall__Outputs(this);
   }
 }
 
 export class BurnFromCall__Inputs {
-  _call: BurnFromCall
+  _call: BurnFromCall;
 
   constructor(call: BurnFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get account(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class BurnFromCall__Outputs {
-  _call: BurnFromCall
+  _call: BurnFromCall;
 
   constructor(call: BurnFromCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class DecreaseAllowanceCall extends ethereum.Call {
   get inputs(): DecreaseAllowanceCall__Inputs {
-    return new DecreaseAllowanceCall__Inputs(this)
+    return new DecreaseAllowanceCall__Inputs(this);
   }
 
   get outputs(): DecreaseAllowanceCall__Outputs {
-    return new DecreaseAllowanceCall__Outputs(this)
+    return new DecreaseAllowanceCall__Outputs(this);
   }
 }
 
 export class DecreaseAllowanceCall__Inputs {
-  _call: DecreaseAllowanceCall
+  _call: DecreaseAllowanceCall;
 
   constructor(call: DecreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get spender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get subtractedValue(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class DecreaseAllowanceCall__Outputs {
-  _call: DecreaseAllowanceCall
+  _call: DecreaseAllowanceCall;
 
   constructor(call: DecreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class GrantRoleCall extends ethereum.Call {
   get inputs(): GrantRoleCall__Inputs {
-    return new GrantRoleCall__Inputs(this)
+    return new GrantRoleCall__Inputs(this);
   }
 
   get outputs(): GrantRoleCall__Outputs {
-    return new GrantRoleCall__Outputs(this)
+    return new GrantRoleCall__Outputs(this);
   }
 }
 
 export class GrantRoleCall__Inputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class GrantRoleCall__Outputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class IncreaseAllowanceCall extends ethereum.Call {
   get inputs(): IncreaseAllowanceCall__Inputs {
-    return new IncreaseAllowanceCall__Inputs(this)
+    return new IncreaseAllowanceCall__Inputs(this);
   }
 
   get outputs(): IncreaseAllowanceCall__Outputs {
-    return new IncreaseAllowanceCall__Outputs(this)
+    return new IncreaseAllowanceCall__Outputs(this);
   }
 }
 
 export class IncreaseAllowanceCall__Inputs {
-  _call: IncreaseAllowanceCall
+  _call: IncreaseAllowanceCall;
 
   constructor(call: IncreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get spender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get addedValue(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class IncreaseAllowanceCall__Outputs {
-  _call: IncreaseAllowanceCall
+  _call: IncreaseAllowanceCall;
 
   constructor(call: IncreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class InitializeCall extends ethereum.Call {
   get inputs(): InitializeCall__Inputs {
-    return new InitializeCall__Inputs(this)
+    return new InitializeCall__Inputs(this);
   }
 
   get outputs(): InitializeCall__Outputs {
-    return new InitializeCall__Outputs(this)
+    return new InitializeCall__Outputs(this);
   }
 }
 
 export class InitializeCall__Inputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _name(): string {
-    return this._call.inputValues[0].value.toString()
+    return this._call.inputValues[0].value.toString();
   }
 
   get _symbol(): string {
-    return this._call.inputValues[1].value.toString()
+    return this._call.inputValues[1].value.toString();
   }
 
   get _decimals(): i32 {
-    return this._call.inputValues[2].value.toI32()
+    return this._call.inputValues[2].value.toI32();
   }
 }
 
 export class InitializeCall__Outputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class MintCall extends ethereum.Call {
   get inputs(): MintCall__Inputs {
-    return new MintCall__Inputs(this)
+    return new MintCall__Inputs(this);
   }
 
   get outputs(): MintCall__Outputs {
-    return new MintCall__Outputs(this)
+    return new MintCall__Outputs(this);
   }
 }
 
 export class MintCall__Inputs {
-  _call: MintCall
+  _call: MintCall;
 
   constructor(call: MintCall) {
-    this._call = call
+    this._call = call;
   }
 
   get to(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class MintCall__Outputs {
-  _call: MintCall
+  _call: MintCall;
 
   constructor(call: MintCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceRoleCall extends ethereum.Call {
   get inputs(): RenounceRoleCall__Inputs {
-    return new RenounceRoleCall__Inputs(this)
+    return new RenounceRoleCall__Inputs(this);
   }
 
   get outputs(): RenounceRoleCall__Outputs {
-    return new RenounceRoleCall__Outputs(this)
+    return new RenounceRoleCall__Outputs(this);
   }
 }
 
 export class RenounceRoleCall__Inputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RenounceRoleCall__Outputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RevokeRoleCall extends ethereum.Call {
   get inputs(): RevokeRoleCall__Inputs {
-    return new RevokeRoleCall__Inputs(this)
+    return new RevokeRoleCall__Inputs(this);
   }
 
   get outputs(): RevokeRoleCall__Outputs {
-    return new RevokeRoleCall__Outputs(this)
+    return new RevokeRoleCall__Outputs(this);
   }
 }
 
 export class RevokeRoleCall__Inputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RevokeRoleCall__Outputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class TransferCall extends ethereum.Call {
   get inputs(): TransferCall__Inputs {
-    return new TransferCall__Inputs(this)
+    return new TransferCall__Inputs(this);
   }
 
   get outputs(): TransferCall__Outputs {
-    return new TransferCall__Outputs(this)
+    return new TransferCall__Outputs(this);
   }
 }
 
 export class TransferCall__Inputs {
-  _call: TransferCall
+  _call: TransferCall;
 
   constructor(call: TransferCall) {
-    this._call = call
+    this._call = call;
   }
 
   get recipient(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class TransferCall__Outputs {
-  _call: TransferCall
+  _call: TransferCall;
 
   constructor(call: TransferCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class TransferFromCall extends ethereum.Call {
   get inputs(): TransferFromCall__Inputs {
-    return new TransferFromCall__Inputs(this)
+    return new TransferFromCall__Inputs(this);
   }
 
   get outputs(): TransferFromCall__Outputs {
-    return new TransferFromCall__Outputs(this)
+    return new TransferFromCall__Outputs(this);
   }
 }
 
 export class TransferFromCall__Inputs {
-  _call: TransferFromCall
+  _call: TransferFromCall;
 
   constructor(call: TransferFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get sender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get recipient(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 }
 
 export class TransferFromCall__Outputs {
-  _call: TransferFromCall
+  _call: TransferFromCall;
 
   constructor(call: TransferFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }

--- a/subgraph/generated/PriceOracle/PriceOracle.ts
+++ b/subgraph/generated/PriceOracle/PriceOracle.ts
@@ -7,154 +7,154 @@ import {
   Entity,
   Bytes,
   Address,
-  BigInt,
-} from "@graphprotocol/graph-ts"
+  BigInt
+} from "@graphprotocol/graph-ts";
 
 export class CodeAddressUpdated extends ethereum.Event {
   get params(): CodeAddressUpdated__Params {
-    return new CodeAddressUpdated__Params(this)
+    return new CodeAddressUpdated__Params(this);
   }
 }
 
 export class CodeAddressUpdated__Params {
-  _event: CodeAddressUpdated
+  _event: CodeAddressUpdated;
 
   constructor(event: CodeAddressUpdated) {
-    this._event = event
+    this._event = event;
   }
 
   get newAddress(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class OracleSet extends ethereum.Event {
   get params(): OracleSet__Params {
-    return new OracleSet__Params(this)
+    return new OracleSet__Params(this);
   }
 }
 
 export class OracleSet__Params {
-  _event: OracleSet
+  _event: OracleSet;
 
   constructor(event: OracleSet) {
-    this._event = event
+    this._event = event;
   }
 
   get underlyingToken(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get priceToken(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get oracle(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 
   get earliestSettlementDate(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 }
 
 export class OwnershipTransferred extends ethereum.Event {
   get params(): OwnershipTransferred__Params {
-    return new OwnershipTransferred__Params(this)
+    return new OwnershipTransferred__Params(this);
   }
 }
 
 export class OwnershipTransferred__Params {
-  _event: OwnershipTransferred
+  _event: OwnershipTransferred;
 
   constructor(event: OwnershipTransferred) {
-    this._event = event
+    this._event = event;
   }
 
   get previousOwner(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get newOwner(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 }
 
 export class SettlementPriceSet extends ethereum.Event {
   get params(): SettlementPriceSet__Params {
-    return new SettlementPriceSet__Params(this)
+    return new SettlementPriceSet__Params(this);
   }
 }
 
 export class SettlementPriceSet__Params {
-  _event: SettlementPriceSet
+  _event: SettlementPriceSet;
 
   constructor(event: SettlementPriceSet) {
-    this._event = event
+    this._event = event;
   }
 
   get underlyingToken(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get priceToken(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get settlementDate(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 
   get price(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 }
 
 export class PriceOracle__getSettlementPriceResult {
-  value0: boolean
-  value1: BigInt
+  value0: boolean;
+  value1: BigInt;
 
   constructor(value0: boolean, value1: BigInt) {
-    this.value0 = value0
-    this.value1 = value1
+    this.value0 = value0;
+    this.value1 = value1;
   }
 
   toMap(): TypedMap<string, ethereum.Value> {
-    let map = new TypedMap<string, ethereum.Value>()
-    map.set("value0", ethereum.Value.fromBoolean(this.value0))
-    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1))
-    return map
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromBoolean(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    return map;
   }
 }
 
 export class PriceOracle extends ethereum.SmartContract {
   static bind(address: Address): PriceOracle {
-    return new PriceOracle("PriceOracle", address)
+    return new PriceOracle("PriceOracle", address);
   }
 
   get8amWeeklyOrDailyAligned(_timestamp: BigInt): BigInt {
     let result = super.call(
       "get8amWeeklyOrDailyAligned",
       "get8amWeeklyOrDailyAligned(uint256):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(_timestamp)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_timestamp)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_get8amWeeklyOrDailyAligned(
-    _timestamp: BigInt,
+    _timestamp: BigInt
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "get8amWeeklyOrDailyAligned",
       "get8amWeeklyOrDailyAligned(uint256):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(_timestamp)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_timestamp)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getCurrentPrice(underlyingToken: Address, priceToken: Address): BigInt {
@@ -163,59 +163,59 @@ export class PriceOracle extends ethereum.SmartContract {
       "getCurrentPrice(address,address):(uint256)",
       [
         ethereum.Value.fromAddress(underlyingToken),
-        ethereum.Value.fromAddress(priceToken),
-      ],
-    )
+        ethereum.Value.fromAddress(priceToken)
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_getCurrentPrice(
     underlyingToken: Address,
-    priceToken: Address,
+    priceToken: Address
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "getCurrentPrice",
       "getCurrentPrice(address,address):(uint256)",
       [
         ethereum.Value.fromAddress(underlyingToken),
-        ethereum.Value.fromAddress(priceToken),
-      ],
-    )
+        ethereum.Value.fromAddress(priceToken)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getLogicAddress(): Address {
     let result = super.call(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_getLogicAddress(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   getSettlementPrice(
     underlyingToken: Address,
     priceToken: Address,
-    settlementDate: BigInt,
+    settlementDate: BigInt
   ): PriceOracle__getSettlementPriceResult {
     let result = super.call(
       "getSettlementPrice",
@@ -223,20 +223,20 @@ export class PriceOracle extends ethereum.SmartContract {
       [
         ethereum.Value.fromAddress(underlyingToken),
         ethereum.Value.fromAddress(priceToken),
-        ethereum.Value.fromUnsignedBigInt(settlementDate),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(settlementDate)
+      ]
+    );
 
     return new PriceOracle__getSettlementPriceResult(
       result[0].toBoolean(),
-      result[1].toBigInt(),
-    )
+      result[1].toBigInt()
+    );
   }
 
   try_getSettlementPrice(
     underlyingToken: Address,
     priceToken: Address,
-    settlementDate: BigInt,
+    settlementDate: BigInt
   ): ethereum.CallResult<PriceOracle__getSettlementPriceResult> {
     let result = super.tryCall(
       "getSettlementPrice",
@@ -244,274 +244,278 @@ export class PriceOracle extends ethereum.SmartContract {
       [
         ethereum.Value.fromAddress(underlyingToken),
         ethereum.Value.fromAddress(priceToken),
-        ethereum.Value.fromUnsignedBigInt(settlementDate),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(settlementDate)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
+    let value = result.value;
     return ethereum.CallResult.fromValue(
       new PriceOracle__getSettlementPriceResult(
         value[0].toBoolean(),
-        value[1].toBigInt(),
-      ),
-    )
+        value[1].toBigInt()
+      )
+    );
   }
 
   owner(): Address {
-    let result = super.call("owner", "owner():(address)", [])
+    let result = super.call("owner", "owner():(address)", []);
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_owner(): ethereum.CallResult<Address> {
-    let result = super.tryCall("owner", "owner():(address)", [])
+    let result = super.tryCall("owner", "owner():(address)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   proxiableUUID(): Bytes {
-    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_proxiableUUID(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.tryCall(
+      "proxiableUUID",
+      "proxiableUUID():(bytes32)",
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 }
 
 export class AddTokenPairCall extends ethereum.Call {
   get inputs(): AddTokenPairCall__Inputs {
-    return new AddTokenPairCall__Inputs(this)
+    return new AddTokenPairCall__Inputs(this);
   }
 
   get outputs(): AddTokenPairCall__Outputs {
-    return new AddTokenPairCall__Outputs(this)
+    return new AddTokenPairCall__Outputs(this);
   }
 }
 
 export class AddTokenPairCall__Inputs {
-  _call: AddTokenPairCall
+  _call: AddTokenPairCall;
 
   constructor(call: AddTokenPairCall) {
-    this._call = call
+    this._call = call;
   }
 
   get underlyingToken(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get priceToken(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get oracle(): Address {
-    return this._call.inputValues[2].value.toAddress()
+    return this._call.inputValues[2].value.toAddress();
   }
 }
 
 export class AddTokenPairCall__Outputs {
-  _call: AddTokenPairCall
+  _call: AddTokenPairCall;
 
   constructor(call: AddTokenPairCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class InitializeCall extends ethereum.Call {
   get inputs(): InitializeCall__Inputs {
-    return new InitializeCall__Inputs(this)
+    return new InitializeCall__Inputs(this);
   }
 
   get outputs(): InitializeCall__Outputs {
-    return new InitializeCall__Outputs(this)
+    return new InitializeCall__Outputs(this);
   }
 }
 
 export class InitializeCall__Inputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _dateOffset(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 }
 
 export class InitializeCall__Outputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceOwnershipCall extends ethereum.Call {
   get inputs(): RenounceOwnershipCall__Inputs {
-    return new RenounceOwnershipCall__Inputs(this)
+    return new RenounceOwnershipCall__Inputs(this);
   }
 
   get outputs(): RenounceOwnershipCall__Outputs {
-    return new RenounceOwnershipCall__Outputs(this)
+    return new RenounceOwnershipCall__Outputs(this);
   }
 }
 
 export class RenounceOwnershipCall__Inputs {
-  _call: RenounceOwnershipCall
+  _call: RenounceOwnershipCall;
 
   constructor(call: RenounceOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceOwnershipCall__Outputs {
-  _call: RenounceOwnershipCall
+  _call: RenounceOwnershipCall;
 
   constructor(call: RenounceOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class SetSettlementPriceCall extends ethereum.Call {
   get inputs(): SetSettlementPriceCall__Inputs {
-    return new SetSettlementPriceCall__Inputs(this)
+    return new SetSettlementPriceCall__Inputs(this);
   }
 
   get outputs(): SetSettlementPriceCall__Outputs {
-    return new SetSettlementPriceCall__Outputs(this)
+    return new SetSettlementPriceCall__Outputs(this);
   }
 }
 
 export class SetSettlementPriceCall__Inputs {
-  _call: SetSettlementPriceCall
+  _call: SetSettlementPriceCall;
 
   constructor(call: SetSettlementPriceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get underlyingToken(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get priceToken(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class SetSettlementPriceCall__Outputs {
-  _call: SetSettlementPriceCall
+  _call: SetSettlementPriceCall;
 
   constructor(call: SetSettlementPriceCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class SetSettlementPriceForDateCall extends ethereum.Call {
   get inputs(): SetSettlementPriceForDateCall__Inputs {
-    return new SetSettlementPriceForDateCall__Inputs(this)
+    return new SetSettlementPriceForDateCall__Inputs(this);
   }
 
   get outputs(): SetSettlementPriceForDateCall__Outputs {
-    return new SetSettlementPriceForDateCall__Outputs(this)
+    return new SetSettlementPriceForDateCall__Outputs(this);
   }
 }
 
 export class SetSettlementPriceForDateCall__Inputs {
-  _call: SetSettlementPriceForDateCall
+  _call: SetSettlementPriceForDateCall;
 
   constructor(call: SetSettlementPriceForDateCall) {
-    this._call = call
+    this._call = call;
   }
 
   get underlyingToken(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get priceToken(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get date(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 }
 
 export class SetSettlementPriceForDateCall__Outputs {
-  _call: SetSettlementPriceForDateCall
+  _call: SetSettlementPriceForDateCall;
 
   constructor(call: SetSettlementPriceForDateCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class TransferOwnershipCall extends ethereum.Call {
   get inputs(): TransferOwnershipCall__Inputs {
-    return new TransferOwnershipCall__Inputs(this)
+    return new TransferOwnershipCall__Inputs(this);
   }
 
   get outputs(): TransferOwnershipCall__Outputs {
-    return new TransferOwnershipCall__Outputs(this)
+    return new TransferOwnershipCall__Outputs(this);
   }
 }
 
 export class TransferOwnershipCall__Inputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 
   get newOwner(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class TransferOwnershipCall__Outputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UpdateImplementationCall extends ethereum.Call {
   get inputs(): UpdateImplementationCall__Inputs {
-    return new UpdateImplementationCall__Inputs(this)
+    return new UpdateImplementationCall__Inputs(this);
   }
 
   get outputs(): UpdateImplementationCall__Outputs {
-    return new UpdateImplementationCall__Outputs(this)
+    return new UpdateImplementationCall__Outputs(this);
   }
 }
 
 export class UpdateImplementationCall__Inputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 
   get newPriceOracleImpl(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class UpdateImplementationCall__Outputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 }

--- a/subgraph/generated/SeriesController/SeriesController.ts
+++ b/subgraph/generated/SeriesController/SeriesController.ts
@@ -7,625 +7,625 @@ import {
   Entity,
   Bytes,
   Address,
-  BigInt,
-} from "@graphprotocol/graph-ts"
+  BigInt
+} from "@graphprotocol/graph-ts";
 
 export class CodeAddressUpdated extends ethereum.Event {
   get params(): CodeAddressUpdated__Params {
-    return new CodeAddressUpdated__Params(this)
+    return new CodeAddressUpdated__Params(this);
   }
 }
 
 export class CodeAddressUpdated__Params {
-  _event: CodeAddressUpdated
+  _event: CodeAddressUpdated;
 
   constructor(event: CodeAddressUpdated) {
-    this._event = event
+    this._event = event;
   }
 
   get newAddress(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class CollateralClaimed extends ethereum.Event {
   get params(): CollateralClaimed__Params {
-    return new CollateralClaimed__Params(this)
+    return new CollateralClaimed__Params(this);
   }
 }
 
 export class CollateralClaimed__Params {
-  _event: CollateralClaimed
+  _event: CollateralClaimed;
 
   constructor(event: CollateralClaimed) {
-    this._event = event
+    this._event = event;
   }
 
   get redeemer(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get optionTokenAmount(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 
   get wTokenTotalSupply(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 
   get bTokenTotalSupply(): BigInt {
-    return this._event.parameters[4].value.toBigInt()
+    return this._event.parameters[4].value.toBigInt();
   }
 
   get collateralAmount(): BigInt {
-    return this._event.parameters[5].value.toBigInt()
+    return this._event.parameters[5].value.toBigInt();
   }
 }
 
 export class ERC20VaultTransferIn extends ethereum.Event {
   get params(): ERC20VaultTransferIn__Params {
-    return new ERC20VaultTransferIn__Params(this)
+    return new ERC20VaultTransferIn__Params(this);
   }
 }
 
 export class ERC20VaultTransferIn__Params {
-  _event: ERC20VaultTransferIn
+  _event: ERC20VaultTransferIn;
 
   constructor(event: ERC20VaultTransferIn) {
-    this._event = event
+    this._event = event;
   }
 
   get sender(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get amount(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class ERC20VaultTransferOut extends ethereum.Event {
   get params(): ERC20VaultTransferOut__Params {
-    return new ERC20VaultTransferOut__Params(this)
+    return new ERC20VaultTransferOut__Params(this);
   }
 }
 
 export class ERC20VaultTransferOut__Params {
-  _event: ERC20VaultTransferOut
+  _event: ERC20VaultTransferOut;
 
   constructor(event: ERC20VaultTransferOut) {
-    this._event = event
+    this._event = event;
   }
 
   get recipient(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get amount(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class FeePaid extends ethereum.Event {
   get params(): FeePaid__Params {
-    return new FeePaid__Params(this)
+    return new FeePaid__Params(this);
   }
 }
 
 export class FeePaid__Params {
-  _event: FeePaid
+  _event: FeePaid;
 
   constructor(event: FeePaid) {
-    this._event = event
+    this._event = event;
   }
 
   get feeType(): i32 {
-    return this._event.parameters[0].value.toI32()
+    return this._event.parameters[0].value.toI32();
   }
 
   get token(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get value(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class OptionClosed extends ethereum.Event {
   get params(): OptionClosed__Params {
-    return new OptionClosed__Params(this)
+    return new OptionClosed__Params(this);
   }
 }
 
 export class OptionClosed__Params {
-  _event: OptionClosed
+  _event: OptionClosed;
 
   constructor(event: OptionClosed) {
-    this._event = event
+    this._event = event;
   }
 
   get redeemer(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get optionTokenAmount(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 
   get wTokenTotalSupply(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 
   get bTokenTotalSupply(): BigInt {
-    return this._event.parameters[4].value.toBigInt()
+    return this._event.parameters[4].value.toBigInt();
   }
 
   get collateralAmount(): BigInt {
-    return this._event.parameters[5].value.toBigInt()
+    return this._event.parameters[5].value.toBigInt();
   }
 }
 
 export class OptionExercised extends ethereum.Event {
   get params(): OptionExercised__Params {
-    return new OptionExercised__Params(this)
+    return new OptionExercised__Params(this);
   }
 }
 
 export class OptionExercised__Params {
-  _event: OptionExercised
+  _event: OptionExercised;
 
   constructor(event: OptionExercised) {
-    this._event = event
+    this._event = event;
   }
 
   get redeemer(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get optionTokenAmount(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 
   get wTokenTotalSupply(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 
   get bTokenTotalSupply(): BigInt {
-    return this._event.parameters[4].value.toBigInt()
+    return this._event.parameters[4].value.toBigInt();
   }
 
   get collateralAmount(): BigInt {
-    return this._event.parameters[5].value.toBigInt()
+    return this._event.parameters[5].value.toBigInt();
   }
 }
 
 export class OptionMinted extends ethereum.Event {
   get params(): OptionMinted__Params {
-    return new OptionMinted__Params(this)
+    return new OptionMinted__Params(this);
   }
 }
 
 export class OptionMinted__Params {
-  _event: OptionMinted
+  _event: OptionMinted;
 
   constructor(event: OptionMinted) {
-    this._event = event
+    this._event = event;
   }
 
   get minter(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get optionTokenAmount(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 
   get wTokenTotalSupply(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 
   get bTokenTotalSupply(): BigInt {
-    return this._event.parameters[4].value.toBigInt()
+    return this._event.parameters[4].value.toBigInt();
   }
 }
 
 export class Paused extends ethereum.Event {
   get params(): Paused__Params {
-    return new Paused__Params(this)
+    return new Paused__Params(this);
   }
 }
 
 export class Paused__Params {
-  _event: Paused
+  _event: Paused;
 
   constructor(event: Paused) {
-    this._event = event
+    this._event = event;
   }
 
   get account(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class RoleAdminChanged extends ethereum.Event {
   get params(): RoleAdminChanged__Params {
-    return new RoleAdminChanged__Params(this)
+    return new RoleAdminChanged__Params(this);
   }
 }
 
 export class RoleAdminChanged__Params {
-  _event: RoleAdminChanged
+  _event: RoleAdminChanged;
 
   constructor(event: RoleAdminChanged) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get previousAdminRole(): Bytes {
-    return this._event.parameters[1].value.toBytes()
+    return this._event.parameters[1].value.toBytes();
   }
 
   get newAdminRole(): Bytes {
-    return this._event.parameters[2].value.toBytes()
+    return this._event.parameters[2].value.toBytes();
   }
 }
 
 export class RoleGranted extends ethereum.Event {
   get params(): RoleGranted__Params {
-    return new RoleGranted__Params(this)
+    return new RoleGranted__Params(this);
   }
 }
 
 export class RoleGranted__Params {
-  _event: RoleGranted
+  _event: RoleGranted;
 
   constructor(event: RoleGranted) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class RoleRevoked extends ethereum.Event {
   get params(): RoleRevoked__Params {
-    return new RoleRevoked__Params(this)
+    return new RoleRevoked__Params(this);
   }
 }
 
 export class RoleRevoked__Params {
-  _event: RoleRevoked
+  _event: RoleRevoked;
 
   constructor(event: RoleRevoked) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class SeriesControllerInitialized extends ethereum.Event {
   get params(): SeriesControllerInitialized__Params {
-    return new SeriesControllerInitialized__Params(this)
+    return new SeriesControllerInitialized__Params(this);
   }
 }
 
 export class SeriesControllerInitialized__Params {
-  _event: SeriesControllerInitialized
+  _event: SeriesControllerInitialized;
 
   constructor(event: SeriesControllerInitialized) {
-    this._event = event
+    this._event = event;
   }
 
   get priceOracle(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get vault(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get erc1155Controller(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 
   get fees(): SeriesControllerInitializedFeesStruct {
-    return this._event.parameters[3].value.toTuple() as SeriesControllerInitializedFeesStruct
+    return this._event.parameters[3].value.toTuple() as SeriesControllerInitializedFeesStruct;
   }
 }
 
 export class SeriesControllerInitializedFeesStruct extends ethereum.Tuple {
   get feeReceiver(): Address {
-    return this[0].toAddress()
+    return this[0].toAddress();
   }
 
   get exerciseFeeBasisPoints(): i32 {
-    return this[1].toI32()
+    return this[1].toI32();
   }
 
   get closeFeeBasisPoints(): i32 {
-    return this[2].toI32()
+    return this[2].toI32();
   }
 
   get claimFeeBasisPoints(): i32 {
-    return this[3].toI32()
+    return this[3].toI32();
   }
 }
 
 export class SeriesCreated extends ethereum.Event {
   get params(): SeriesCreated__Params {
-    return new SeriesCreated__Params(this)
+    return new SeriesCreated__Params(this);
   }
 }
 
 export class SeriesCreated__Params {
-  _event: SeriesCreated
+  _event: SeriesCreated;
 
   constructor(event: SeriesCreated) {
-    this._event = event
+    this._event = event;
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[0].value.toBigInt()
+    return this._event.parameters[0].value.toBigInt();
   }
 
   get tokens(): SeriesCreatedTokensStruct {
-    return this._event.parameters[1].value.toTuple() as SeriesCreatedTokensStruct
+    return this._event.parameters[1].value.toTuple() as SeriesCreatedTokensStruct;
   }
 
   get restrictedMinters(): Array<Address> {
-    return this._event.parameters[2].value.toAddressArray()
+    return this._event.parameters[2].value.toAddressArray();
   }
 
   get strikePrice(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 
   get expirationDate(): BigInt {
-    return this._event.parameters[4].value.toBigInt()
+    return this._event.parameters[4].value.toBigInt();
   }
 
   get isPutOption(): boolean {
-    return this._event.parameters[5].value.toBoolean()
+    return this._event.parameters[5].value.toBoolean();
   }
 }
 
 export class SeriesCreatedTokensStruct extends ethereum.Tuple {
   get underlyingToken(): Address {
-    return this[0].toAddress()
+    return this[0].toAddress();
   }
 
   get priceToken(): Address {
-    return this[1].toAddress()
+    return this[1].toAddress();
   }
 
   get collateralToken(): Address {
-    return this[2].toAddress()
+    return this[2].toAddress();
   }
 }
 
 export class Unpaused extends ethereum.Event {
   get params(): Unpaused__Params {
-    return new Unpaused__Params(this)
+    return new Unpaused__Params(this);
   }
 }
 
 export class Unpaused__Params {
-  _event: Unpaused
+  _event: Unpaused;
 
   constructor(event: Unpaused) {
-    this._event = event
+    this._event = event;
   }
 
   get account(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class SeriesController__getClaimAmountResult {
-  value0: BigInt
-  value1: BigInt
+  value0: BigInt;
+  value1: BigInt;
 
   constructor(value0: BigInt, value1: BigInt) {
-    this.value0 = value0
-    this.value1 = value1
+    this.value0 = value0;
+    this.value1 = value1;
   }
 
   toMap(): TypedMap<string, ethereum.Value> {
-    let map = new TypedMap<string, ethereum.Value>()
-    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0))
-    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1))
-    return map
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    return map;
   }
 }
 
 export class SeriesController__getExerciseAmountResult {
-  value0: BigInt
-  value1: BigInt
+  value0: BigInt;
+  value1: BigInt;
 
   constructor(value0: BigInt, value1: BigInt) {
-    this.value0 = value0
-    this.value1 = value1
+    this.value0 = value0;
+    this.value1 = value1;
   }
 
   toMap(): TypedMap<string, ethereum.Value> {
-    let map = new TypedMap<string, ethereum.Value>()
-    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0))
-    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1))
-    return map
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    return map;
   }
 }
 
 export class SeriesController__getSettlementPriceResult {
-  value0: boolean
-  value1: BigInt
+  value0: boolean;
+  value1: BigInt;
 
   constructor(value0: boolean, value1: BigInt) {
-    this.value0 = value0
-    this.value1 = value1
+    this.value0 = value0;
+    this.value1 = value1;
   }
 
   toMap(): TypedMap<string, ethereum.Value> {
-    let map = new TypedMap<string, ethereum.Value>()
-    map.set("value0", ethereum.Value.fromBoolean(this.value0))
-    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1))
-    return map
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromBoolean(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    return map;
   }
 }
 
 export class SeriesController__seriesResultValue0Struct extends ethereum.Tuple {
   get expirationDate(): BigInt {
-    return this[0].toBigInt()
+    return this[0].toBigInt();
   }
 
   get isPutOption(): boolean {
-    return this[1].toBoolean()
+    return this[1].toBoolean();
   }
 
   get tokens(): SeriesController__seriesResultValue0TokensStruct {
-    return this[2].toTuple() as SeriesController__seriesResultValue0TokensStruct
+    return this[2].toTuple() as SeriesController__seriesResultValue0TokensStruct;
   }
 
   get strikePrice(): BigInt {
-    return this[3].toBigInt()
+    return this[3].toBigInt();
   }
 }
 
 export class SeriesController__seriesResultValue0TokensStruct extends ethereum.Tuple {
   get underlyingToken(): Address {
-    return this[0].toAddress()
+    return this[0].toAddress();
   }
 
   get priceToken(): Address {
-    return this[1].toAddress()
+    return this[1].toAddress();
   }
 
   get collateralToken(): Address {
-    return this[2].toAddress()
+    return this[2].toAddress();
   }
 }
 
 export class SeriesController extends ethereum.SmartContract {
   static bind(address: Address): SeriesController {
-    return new SeriesController("SeriesController", address)
+    return new SeriesController("SeriesController", address);
   }
 
   DEFAULT_ADMIN_ROLE(): Bytes {
     let result = super.call(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_DEFAULT_ADMIN_ROLE(): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   MINTER_ROLE(): Bytes {
-    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_MINTER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   PAUSER_ROLE(): Bytes {
-    let result = super.call("PAUSER_ROLE", "PAUSER_ROLE():(bytes32)", [])
+    let result = super.call("PAUSER_ROLE", "PAUSER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_PAUSER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("PAUSER_ROLE", "PAUSER_ROLE():(bytes32)", [])
+    let result = super.tryCall("PAUSER_ROLE", "PAUSER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   bTokenIndex(_seriesId: BigInt): BigInt {
     let result = super.call("bTokenIndex", "bTokenIndex(uint64):(uint256)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_bTokenIndex(_seriesId: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall("bTokenIndex", "bTokenIndex(uint64):(uint256)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   calculateFee(amount: BigInt, basisPoints: i32): BigInt {
@@ -634,1162 +634,1166 @@ export class SeriesController extends ethereum.SmartContract {
       "calculateFee(uint256,uint16):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(amount),
-        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(basisPoints)),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(basisPoints))
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_calculateFee(
     amount: BigInt,
-    basisPoints: i32,
+    basisPoints: i32
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "calculateFee",
       "calculateFee(uint256,uint16):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(amount),
-        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(basisPoints)),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(basisPoints))
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   claimFeeBasisPoints(_seriesId: BigInt): i32 {
     let result = super.call(
       "claimFeeBasisPoints",
       "claimFeeBasisPoints(uint64):(uint16)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_claimFeeBasisPoints(_seriesId: BigInt): ethereum.CallResult<i32> {
     let result = super.tryCall(
       "claimFeeBasisPoints",
       "claimFeeBasisPoints(uint64):(uint16)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   closeFeeBasisPoints(_seriesId: BigInt): i32 {
     let result = super.call(
       "closeFeeBasisPoints",
       "closeFeeBasisPoints(uint64):(uint16)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_closeFeeBasisPoints(_seriesId: BigInt): ethereum.CallResult<i32> {
     let result = super.tryCall(
       "closeFeeBasisPoints",
       "closeFeeBasisPoints(uint64):(uint16)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   collateralToken(_seriesId: BigInt): Address {
     let result = super.call(
       "collateralToken",
       "collateralToken(uint64):(address)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_collateralToken(_seriesId: BigInt): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "collateralToken",
       "collateralToken(uint64):(address)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   erc1155Controller(): Address {
     let result = super.call(
       "erc1155Controller",
       "erc1155Controller():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_erc1155Controller(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "erc1155Controller",
       "erc1155Controller():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   exerciseFeeBasisPoints(_seriesId: BigInt): i32 {
     let result = super.call(
       "exerciseFeeBasisPoints",
       "exerciseFeeBasisPoints(uint64):(uint16)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_exerciseFeeBasisPoints(_seriesId: BigInt): ethereum.CallResult<i32> {
     let result = super.tryCall(
       "exerciseFeeBasisPoints",
       "exerciseFeeBasisPoints(uint64):(uint16)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   expirationDate(_seriesId: BigInt): BigInt {
     let result = super.call(
       "expirationDate",
       "expirationDate(uint64):(uint40)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_expirationDate(_seriesId: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "expirationDate",
       "expirationDate(uint64):(uint40)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getClaimAmount(
     _seriesId: BigInt,
-    _wTokenAmount: BigInt,
+    _wTokenAmount: BigInt
   ): SeriesController__getClaimAmountResult {
     let result = super.call(
       "getClaimAmount",
       "getClaimAmount(uint64,uint256):(uint256,uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(_seriesId),
-        ethereum.Value.fromUnsignedBigInt(_wTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(_wTokenAmount)
+      ]
+    );
 
     return new SeriesController__getClaimAmountResult(
       result[0].toBigInt(),
-      result[1].toBigInt(),
-    )
+      result[1].toBigInt()
+    );
   }
 
   try_getClaimAmount(
     _seriesId: BigInt,
-    _wTokenAmount: BigInt,
+    _wTokenAmount: BigInt
   ): ethereum.CallResult<SeriesController__getClaimAmountResult> {
     let result = super.tryCall(
       "getClaimAmount",
       "getClaimAmount(uint64,uint256):(uint256,uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(_seriesId),
-        ethereum.Value.fromUnsignedBigInt(_wTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(_wTokenAmount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
+    let value = result.value;
     return ethereum.CallResult.fromValue(
       new SeriesController__getClaimAmountResult(
         value[0].toBigInt(),
-        value[1].toBigInt(),
-      ),
-    )
+        value[1].toBigInt()
+      )
+    );
   }
 
   getCollateralPerOptionToken(
     _seriesId: BigInt,
-    _optionTokenAmount: BigInt,
+    _optionTokenAmount: BigInt
   ): BigInt {
     let result = super.call(
       "getCollateralPerOptionToken",
       "getCollateralPerOptionToken(uint64,uint256):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(_seriesId),
-        ethereum.Value.fromUnsignedBigInt(_optionTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(_optionTokenAmount)
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_getCollateralPerOptionToken(
     _seriesId: BigInt,
-    _optionTokenAmount: BigInt,
+    _optionTokenAmount: BigInt
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "getCollateralPerOptionToken",
       "getCollateralPerOptionToken(uint64,uint256):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(_seriesId),
-        ethereum.Value.fromUnsignedBigInt(_optionTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(_optionTokenAmount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getExerciseAmount(
     _seriesId: BigInt,
-    _bTokenAmount: BigInt,
+    _bTokenAmount: BigInt
   ): SeriesController__getExerciseAmountResult {
     let result = super.call(
       "getExerciseAmount",
       "getExerciseAmount(uint64,uint256):(uint256,uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(_seriesId),
-        ethereum.Value.fromUnsignedBigInt(_bTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(_bTokenAmount)
+      ]
+    );
 
     return new SeriesController__getExerciseAmountResult(
       result[0].toBigInt(),
-      result[1].toBigInt(),
-    )
+      result[1].toBigInt()
+    );
   }
 
   try_getExerciseAmount(
     _seriesId: BigInt,
-    _bTokenAmount: BigInt,
+    _bTokenAmount: BigInt
   ): ethereum.CallResult<SeriesController__getExerciseAmountResult> {
     let result = super.tryCall(
       "getExerciseAmount",
       "getExerciseAmount(uint64,uint256):(uint256,uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(_seriesId),
-        ethereum.Value.fromUnsignedBigInt(_bTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(_bTokenAmount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
+    let value = result.value;
     return ethereum.CallResult.fromValue(
       new SeriesController__getExerciseAmountResult(
         value[0].toBigInt(),
-        value[1].toBigInt(),
-      ),
-    )
+        value[1].toBigInt()
+      )
+    );
   }
 
   getLogicAddress(): Address {
     let result = super.call(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_getLogicAddress(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   getRoleAdmin(role: Bytes): Bytes {
     let result = super.call("getRoleAdmin", "getRoleAdmin(bytes32):(bytes32)", [
-      ethereum.Value.fromFixedBytes(role),
-    ])
+      ethereum.Value.fromFixedBytes(role)
+    ]);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_getRoleAdmin(role: Bytes): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "getRoleAdmin",
       "getRoleAdmin(bytes32):(bytes32)",
-      [ethereum.Value.fromFixedBytes(role)],
-    )
+      [ethereum.Value.fromFixedBytes(role)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   getSeriesERC20Balance(_seriesId: BigInt): BigInt {
     let result = super.call(
       "getSeriesERC20Balance",
       "getSeriesERC20Balance(uint64):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_getSeriesERC20Balance(_seriesId: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "getSeriesERC20Balance",
       "getSeriesERC20Balance(uint64):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getSettlementPrice(
-    _seriesId: BigInt,
+    _seriesId: BigInt
   ): SeriesController__getSettlementPriceResult {
     let result = super.call(
       "getSettlementPrice",
       "getSettlementPrice(uint64):(bool,uint256)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
     return new SeriesController__getSettlementPriceResult(
       result[0].toBoolean(),
-      result[1].toBigInt(),
-    )
+      result[1].toBigInt()
+    );
   }
 
   try_getSettlementPrice(
-    _seriesId: BigInt,
+    _seriesId: BigInt
   ): ethereum.CallResult<SeriesController__getSettlementPriceResult> {
     let result = super.tryCall(
       "getSettlementPrice",
       "getSettlementPrice(uint64):(bool,uint256)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
+    let value = result.value;
     return ethereum.CallResult.fromValue(
       new SeriesController__getSettlementPriceResult(
         value[0].toBoolean(),
-        value[1].toBigInt(),
-      ),
-    )
+        value[1].toBigInt()
+      )
+    );
   }
 
   hasRole(role: Bytes, account: Address): boolean {
     let result = super.call("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_hasRole(role: Bytes, account: Address): ethereum.CallResult<boolean> {
     let result = super.tryCall("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   isPutOption(_seriesId: BigInt): boolean {
     let result = super.call("isPutOption", "isPutOption(uint64):(bool)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_isPutOption(_seriesId: BigInt): ethereum.CallResult<boolean> {
     let result = super.tryCall("isPutOption", "isPutOption(uint64):(bool)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   latestIndex(): BigInt {
-    let result = super.call("latestIndex", "latestIndex():(uint64)", [])
+    let result = super.call("latestIndex", "latestIndex():(uint64)", []);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_latestIndex(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall("latestIndex", "latestIndex():(uint64)", [])
+    let result = super.tryCall("latestIndex", "latestIndex():(uint64)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   paused(): boolean {
-    let result = super.call("paused", "paused():(bool)", [])
+    let result = super.call("paused", "paused():(bool)", []);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_paused(): ethereum.CallResult<boolean> {
-    let result = super.tryCall("paused", "paused():(bool)", [])
+    let result = super.tryCall("paused", "paused():(bool)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   priceDecimals(): i32 {
-    let result = super.call("priceDecimals", "priceDecimals():(uint8)", [])
+    let result = super.call("priceDecimals", "priceDecimals():(uint8)", []);
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_priceDecimals(): ethereum.CallResult<i32> {
-    let result = super.tryCall("priceDecimals", "priceDecimals():(uint8)", [])
+    let result = super.tryCall("priceDecimals", "priceDecimals():(uint8)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   priceToken(_seriesId: BigInt): Address {
     let result = super.call("priceToken", "priceToken(uint64):(address)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_priceToken(_seriesId: BigInt): ethereum.CallResult<Address> {
     let result = super.tryCall("priceToken", "priceToken(uint64):(address)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   proxiableUUID(): Bytes {
-    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_proxiableUUID(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.tryCall(
+      "proxiableUUID",
+      "proxiableUUID():(bytes32)",
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   series(seriesId: BigInt): SeriesController__seriesResultValue0Struct {
     let result = super.call(
       "series",
       "series(uint256):((uint40,bool,(address,address,address),uint256))",
-      [ethereum.Value.fromUnsignedBigInt(seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(seriesId)]
+    );
 
-    return result[0].toTuple() as SeriesController__seriesResultValue0Struct
+    return result[0].toTuple() as SeriesController__seriesResultValue0Struct;
   }
 
   try_series(
-    seriesId: BigInt,
+    seriesId: BigInt
   ): ethereum.CallResult<SeriesController__seriesResultValue0Struct> {
     let result = super.tryCall(
       "series",
       "series(uint256):((uint40,bool,(address,address,address),uint256))",
-      [ethereum.Value.fromUnsignedBigInt(seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
+    let value = result.value;
     return ethereum.CallResult.fromValue(
-      value[0].toTuple() as SeriesController__seriesResultValue0Struct,
-    )
+      value[0].toTuple() as SeriesController__seriesResultValue0Struct
+    );
   }
 
   seriesName(_seriesId: BigInt): string {
     let result = super.call("seriesName", "seriesName(uint64):(string)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toString()
+    return result[0].toString();
   }
 
   try_seriesName(_seriesId: BigInt): ethereum.CallResult<string> {
     let result = super.tryCall("seriesName", "seriesName(uint64):(string)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toString())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toString());
   }
 
   state(_seriesId: BigInt): i32 {
     let result = super.call("state", "state(uint64):(uint8)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_state(_seriesId: BigInt): ethereum.CallResult<i32> {
     let result = super.tryCall("state", "state(uint64):(uint8)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   strikePrice(_seriesId: BigInt): BigInt {
     let result = super.call("strikePrice", "strikePrice(uint64):(uint256)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_strikePrice(_seriesId: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall("strikePrice", "strikePrice(uint64):(uint256)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   supportsInterface(interfaceId: Bytes): boolean {
     let result = super.call(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_supportsInterface(interfaceId: Bytes): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   underlyingToken(_seriesId: BigInt): Address {
     let result = super.call(
       "underlyingToken",
       "underlyingToken(uint64):(address)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_underlyingToken(_seriesId: BigInt): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "underlyingToken",
       "underlyingToken(uint64):(address)",
-      [ethereum.Value.fromUnsignedBigInt(_seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(_seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   wTokenIndex(_seriesId: BigInt): BigInt {
     let result = super.call("wTokenIndex", "wTokenIndex(uint64):(uint256)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_wTokenIndex(_seriesId: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall("wTokenIndex", "wTokenIndex(uint64):(uint256)", [
-      ethereum.Value.fromUnsignedBigInt(_seriesId),
-    ])
+      ethereum.Value.fromUnsignedBigInt(_seriesId)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 }
 
 export class __SeriesController_initCall extends ethereum.Call {
   get inputs(): __SeriesController_initCall__Inputs {
-    return new __SeriesController_initCall__Inputs(this)
+    return new __SeriesController_initCall__Inputs(this);
   }
 
   get outputs(): __SeriesController_initCall__Outputs {
-    return new __SeriesController_initCall__Outputs(this)
+    return new __SeriesController_initCall__Outputs(this);
   }
 }
 
 export class __SeriesController_initCall__Inputs {
-  _call: __SeriesController_initCall
+  _call: __SeriesController_initCall;
 
   constructor(call: __SeriesController_initCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _priceOracle(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get _vault(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get _erc1155Controller(): Address {
-    return this._call.inputValues[2].value.toAddress()
+    return this._call.inputValues[2].value.toAddress();
   }
 
   get _fees(): __SeriesController_initCall_feesStruct {
-    return this._call.inputValues[3].value.toTuple() as __SeriesController_initCall_feesStruct
+    return this._call.inputValues[3].value.toTuple() as __SeriesController_initCall_feesStruct;
   }
 }
 
 export class __SeriesController_initCall__Outputs {
-  _call: __SeriesController_initCall
+  _call: __SeriesController_initCall;
 
   constructor(call: __SeriesController_initCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class __SeriesController_initCall_feesStruct extends ethereum.Tuple {
   get feeReceiver(): Address {
-    return this[0].toAddress()
+    return this[0].toAddress();
   }
 
   get exerciseFeeBasisPoints(): i32 {
-    return this[1].toI32()
+    return this[1].toI32();
   }
 
   get closeFeeBasisPoints(): i32 {
-    return this[2].toI32()
+    return this[2].toI32();
   }
 
   get claimFeeBasisPoints(): i32 {
-    return this[3].toI32()
+    return this[3].toI32();
   }
 }
 
 export class ClaimCollateralCall extends ethereum.Call {
   get inputs(): ClaimCollateralCall__Inputs {
-    return new ClaimCollateralCall__Inputs(this)
+    return new ClaimCollateralCall__Inputs(this);
   }
 
   get outputs(): ClaimCollateralCall__Outputs {
-    return new ClaimCollateralCall__Outputs(this)
+    return new ClaimCollateralCall__Outputs(this);
   }
 }
 
 export class ClaimCollateralCall__Inputs {
-  _call: ClaimCollateralCall
+  _call: ClaimCollateralCall;
 
   constructor(call: ClaimCollateralCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get _wTokenAmount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class ClaimCollateralCall__Outputs {
-  _call: ClaimCollateralCall
+  _call: ClaimCollateralCall;
 
   constructor(call: ClaimCollateralCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class ClosePositionCall extends ethereum.Call {
   get inputs(): ClosePositionCall__Inputs {
-    return new ClosePositionCall__Inputs(this)
+    return new ClosePositionCall__Inputs(this);
   }
 
   get outputs(): ClosePositionCall__Outputs {
-    return new ClosePositionCall__Outputs(this)
+    return new ClosePositionCall__Outputs(this);
   }
 }
 
 export class ClosePositionCall__Inputs {
-  _call: ClosePositionCall
+  _call: ClosePositionCall;
 
   constructor(call: ClosePositionCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get _optionTokenAmount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class ClosePositionCall__Outputs {
-  _call: ClosePositionCall
+  _call: ClosePositionCall;
 
   constructor(call: ClosePositionCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class CreateSeriesCall extends ethereum.Call {
   get inputs(): CreateSeriesCall__Inputs {
-    return new CreateSeriesCall__Inputs(this)
+    return new CreateSeriesCall__Inputs(this);
   }
 
   get outputs(): CreateSeriesCall__Outputs {
-    return new CreateSeriesCall__Outputs(this)
+    return new CreateSeriesCall__Outputs(this);
   }
 }
 
 export class CreateSeriesCall__Inputs {
-  _call: CreateSeriesCall
+  _call: CreateSeriesCall;
 
   constructor(call: CreateSeriesCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _tokens(): CreateSeriesCall_tokensStruct {
-    return this._call.inputValues[0].value.toTuple() as CreateSeriesCall_tokensStruct
+    return this._call.inputValues[0].value.toTuple() as CreateSeriesCall_tokensStruct;
   }
 
   get _strikePrices(): Array<BigInt> {
-    return this._call.inputValues[1].value.toBigIntArray()
+    return this._call.inputValues[1].value.toBigIntArray();
   }
 
   get _expirationDates(): Array<BigInt> {
-    return this._call.inputValues[2].value.toBigIntArray()
+    return this._call.inputValues[2].value.toBigIntArray();
   }
 
   get _restrictedMinters(): Array<Address> {
-    return this._call.inputValues[3].value.toAddressArray()
+    return this._call.inputValues[3].value.toAddressArray();
   }
 
   get _isPutOption(): boolean {
-    return this._call.inputValues[4].value.toBoolean()
+    return this._call.inputValues[4].value.toBoolean();
   }
 }
 
 export class CreateSeriesCall__Outputs {
-  _call: CreateSeriesCall
+  _call: CreateSeriesCall;
 
   constructor(call: CreateSeriesCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class CreateSeriesCall_tokensStruct extends ethereum.Tuple {
   get underlyingToken(): Address {
-    return this[0].toAddress()
+    return this[0].toAddress();
   }
 
   get priceToken(): Address {
-    return this[1].toAddress()
+    return this[1].toAddress();
   }
 
   get collateralToken(): Address {
-    return this[2].toAddress()
+    return this[2].toAddress();
   }
 }
 
 export class ExerciseOptionCall extends ethereum.Call {
   get inputs(): ExerciseOptionCall__Inputs {
-    return new ExerciseOptionCall__Inputs(this)
+    return new ExerciseOptionCall__Inputs(this);
   }
 
   get outputs(): ExerciseOptionCall__Outputs {
-    return new ExerciseOptionCall__Outputs(this)
+    return new ExerciseOptionCall__Outputs(this);
   }
 }
 
 export class ExerciseOptionCall__Inputs {
-  _call: ExerciseOptionCall
+  _call: ExerciseOptionCall;
 
   constructor(call: ExerciseOptionCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get _bTokenAmount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 
   get _revertOtm(): boolean {
-    return this._call.inputValues[2].value.toBoolean()
+    return this._call.inputValues[2].value.toBoolean();
   }
 }
 
 export class ExerciseOptionCall__Outputs {
-  _call: ExerciseOptionCall
+  _call: ExerciseOptionCall;
 
   constructor(call: ExerciseOptionCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class GrantRoleCall extends ethereum.Call {
   get inputs(): GrantRoleCall__Inputs {
-    return new GrantRoleCall__Inputs(this)
+    return new GrantRoleCall__Inputs(this);
   }
 
   get outputs(): GrantRoleCall__Outputs {
-    return new GrantRoleCall__Outputs(this)
+    return new GrantRoleCall__Outputs(this);
   }
 }
 
 export class GrantRoleCall__Inputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class GrantRoleCall__Outputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class MintOptionsCall extends ethereum.Call {
   get inputs(): MintOptionsCall__Inputs {
-    return new MintOptionsCall__Inputs(this)
+    return new MintOptionsCall__Inputs(this);
   }
 
   get outputs(): MintOptionsCall__Outputs {
-    return new MintOptionsCall__Outputs(this)
+    return new MintOptionsCall__Outputs(this);
   }
 }
 
 export class MintOptionsCall__Inputs {
-  _call: MintOptionsCall
+  _call: MintOptionsCall;
 
   constructor(call: MintOptionsCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get _optionTokenAmount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class MintOptionsCall__Outputs {
-  _call: MintOptionsCall
+  _call: MintOptionsCall;
 
   constructor(call: MintOptionsCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class PauseCall extends ethereum.Call {
   get inputs(): PauseCall__Inputs {
-    return new PauseCall__Inputs(this)
+    return new PauseCall__Inputs(this);
   }
 
   get outputs(): PauseCall__Outputs {
-    return new PauseCall__Outputs(this)
+    return new PauseCall__Outputs(this);
   }
 }
 
 export class PauseCall__Inputs {
-  _call: PauseCall
+  _call: PauseCall;
 
   constructor(call: PauseCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class PauseCall__Outputs {
-  _call: PauseCall
+  _call: PauseCall;
 
   constructor(call: PauseCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceRoleCall extends ethereum.Call {
   get inputs(): RenounceRoleCall__Inputs {
-    return new RenounceRoleCall__Inputs(this)
+    return new RenounceRoleCall__Inputs(this);
   }
 
   get outputs(): RenounceRoleCall__Outputs {
-    return new RenounceRoleCall__Outputs(this)
+    return new RenounceRoleCall__Outputs(this);
   }
 }
 
 export class RenounceRoleCall__Inputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RenounceRoleCall__Outputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RevokeRoleCall extends ethereum.Call {
   get inputs(): RevokeRoleCall__Inputs {
-    return new RevokeRoleCall__Inputs(this)
+    return new RevokeRoleCall__Inputs(this);
   }
 
   get outputs(): RevokeRoleCall__Outputs {
-    return new RevokeRoleCall__Outputs(this)
+    return new RevokeRoleCall__Outputs(this);
   }
 }
 
 export class RevokeRoleCall__Inputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RevokeRoleCall__Outputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class SetPriceOracleCall extends ethereum.Call {
   get inputs(): SetPriceOracleCall__Inputs {
-    return new SetPriceOracleCall__Inputs(this)
+    return new SetPriceOracleCall__Inputs(this);
   }
 
   get outputs(): SetPriceOracleCall__Outputs {
-    return new SetPriceOracleCall__Outputs(this)
+    return new SetPriceOracleCall__Outputs(this);
   }
 }
 
 export class SetPriceOracleCall__Inputs {
-  _call: SetPriceOracleCall
+  _call: SetPriceOracleCall;
 
   constructor(call: SetPriceOracleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _priceOracle(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class SetPriceOracleCall__Outputs {
-  _call: SetPriceOracleCall
+  _call: SetPriceOracleCall;
 
   constructor(call: SetPriceOracleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class TransferOwnershipCall extends ethereum.Call {
   get inputs(): TransferOwnershipCall__Inputs {
-    return new TransferOwnershipCall__Inputs(this)
+    return new TransferOwnershipCall__Inputs(this);
   }
 
   get outputs(): TransferOwnershipCall__Outputs {
-    return new TransferOwnershipCall__Outputs(this)
+    return new TransferOwnershipCall__Outputs(this);
   }
 }
 
 export class TransferOwnershipCall__Inputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _newAdmin(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class TransferOwnershipCall__Outputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UnpauseCall extends ethereum.Call {
   get inputs(): UnpauseCall__Inputs {
-    return new UnpauseCall__Inputs(this)
+    return new UnpauseCall__Inputs(this);
   }
 
   get outputs(): UnpauseCall__Outputs {
-    return new UnpauseCall__Outputs(this)
+    return new UnpauseCall__Outputs(this);
   }
 }
 
 export class UnpauseCall__Inputs {
-  _call: UnpauseCall
+  _call: UnpauseCall;
 
   constructor(call: UnpauseCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UnpauseCall__Outputs {
-  _call: UnpauseCall
+  _call: UnpauseCall;
 
   constructor(call: UnpauseCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UpdateImplementationCall extends ethereum.Call {
   get inputs(): UpdateImplementationCall__Inputs {
-    return new UpdateImplementationCall__Inputs(this)
+    return new UpdateImplementationCall__Inputs(this);
   }
 
   get outputs(): UpdateImplementationCall__Outputs {
-    return new UpdateImplementationCall__Outputs(this)
+    return new UpdateImplementationCall__Outputs(this);
   }
 }
 
 export class UpdateImplementationCall__Inputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _newImplementation(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class UpdateImplementationCall__Outputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 }

--- a/subgraph/generated/SeriesController/SimpleToken.ts
+++ b/subgraph/generated/SeriesController/SimpleToken.ts
@@ -7,273 +7,273 @@ import {
   Entity,
   Bytes,
   Address,
-  BigInt,
-} from "@graphprotocol/graph-ts"
+  BigInt
+} from "@graphprotocol/graph-ts";
 
 export class Approval extends ethereum.Event {
   get params(): Approval__Params {
-    return new Approval__Params(this)
+    return new Approval__Params(this);
   }
 }
 
 export class Approval__Params {
-  _event: Approval
+  _event: Approval;
 
   constructor(event: Approval) {
-    this._event = event
+    this._event = event;
   }
 
   get owner(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get spender(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get value(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class RoleAdminChanged extends ethereum.Event {
   get params(): RoleAdminChanged__Params {
-    return new RoleAdminChanged__Params(this)
+    return new RoleAdminChanged__Params(this);
   }
 }
 
 export class RoleAdminChanged__Params {
-  _event: RoleAdminChanged
+  _event: RoleAdminChanged;
 
   constructor(event: RoleAdminChanged) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get previousAdminRole(): Bytes {
-    return this._event.parameters[1].value.toBytes()
+    return this._event.parameters[1].value.toBytes();
   }
 
   get newAdminRole(): Bytes {
-    return this._event.parameters[2].value.toBytes()
+    return this._event.parameters[2].value.toBytes();
   }
 }
 
 export class RoleGranted extends ethereum.Event {
   get params(): RoleGranted__Params {
-    return new RoleGranted__Params(this)
+    return new RoleGranted__Params(this);
   }
 }
 
 export class RoleGranted__Params {
-  _event: RoleGranted
+  _event: RoleGranted;
 
   constructor(event: RoleGranted) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class RoleRevoked extends ethereum.Event {
   get params(): RoleRevoked__Params {
-    return new RoleRevoked__Params(this)
+    return new RoleRevoked__Params(this);
   }
 }
 
 export class RoleRevoked__Params {
-  _event: RoleRevoked
+  _event: RoleRevoked;
 
   constructor(event: RoleRevoked) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class Transfer extends ethereum.Event {
   get params(): Transfer__Params {
-    return new Transfer__Params(this)
+    return new Transfer__Params(this);
   }
 }
 
 export class Transfer__Params {
-  _event: Transfer
+  _event: Transfer;
 
   constructor(event: Transfer) {
-    this._event = event
+    this._event = event;
   }
 
   get from(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get to(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get value(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class SimpleToken extends ethereum.SmartContract {
   static bind(address: Address): SimpleToken {
-    return new SimpleToken("SimpleToken", address)
+    return new SimpleToken("SimpleToken", address);
   }
 
   BURNER_ROLE(): Bytes {
-    let result = super.call("BURNER_ROLE", "BURNER_ROLE():(bytes32)", [])
+    let result = super.call("BURNER_ROLE", "BURNER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_BURNER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("BURNER_ROLE", "BURNER_ROLE():(bytes32)", [])
+    let result = super.tryCall("BURNER_ROLE", "BURNER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   DEFAULT_ADMIN_ROLE(): Bytes {
     let result = super.call(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_DEFAULT_ADMIN_ROLE(): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   MINTER_ROLE(): Bytes {
-    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_MINTER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   allowance(owner: Address, spender: Address): BigInt {
     let result = super.call(
       "allowance",
       "allowance(address,address):(uint256)",
-      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)],
-    )
+      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_allowance(owner: Address, spender: Address): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "allowance",
       "allowance(address,address):(uint256)",
-      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)],
-    )
+      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   approve(spender: Address, amount: BigInt): boolean {
     let result = super.call("approve", "approve(address,uint256):(bool)", [
       ethereum.Value.fromAddress(spender),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_approve(spender: Address, amount: BigInt): ethereum.CallResult<boolean> {
     let result = super.tryCall("approve", "approve(address,uint256):(bool)", [
       ethereum.Value.fromAddress(spender),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   balanceOf(account: Address): BigInt {
     let result = super.call("balanceOf", "balanceOf(address):(uint256)", [
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_balanceOf(account: Address): ethereum.CallResult<BigInt> {
     let result = super.tryCall("balanceOf", "balanceOf(address):(uint256)", [
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   decimals(): i32 {
-    let result = super.call("decimals", "decimals():(uint8)", [])
+    let result = super.call("decimals", "decimals():(uint8)", []);
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_decimals(): ethereum.CallResult<i32> {
-    let result = super.tryCall("decimals", "decimals():(uint8)", [])
+    let result = super.tryCall("decimals", "decimals():(uint8)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   decreaseAllowance(spender: Address, subtractedValue: BigInt): boolean {
@@ -282,72 +282,72 @@ export class SimpleToken extends ethereum.SmartContract {
       "decreaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(subtractedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(subtractedValue)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_decreaseAllowance(
     spender: Address,
-    subtractedValue: BigInt,
+    subtractedValue: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "decreaseAllowance",
       "decreaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(subtractedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(subtractedValue)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   getRoleAdmin(role: Bytes): Bytes {
     let result = super.call("getRoleAdmin", "getRoleAdmin(bytes32):(bytes32)", [
-      ethereum.Value.fromFixedBytes(role),
-    ])
+      ethereum.Value.fromFixedBytes(role)
+    ]);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_getRoleAdmin(role: Bytes): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "getRoleAdmin",
       "getRoleAdmin(bytes32):(bytes32)",
-      [ethereum.Value.fromFixedBytes(role)],
-    )
+      [ethereum.Value.fromFixedBytes(role)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   hasRole(role: Bytes, account: Address): boolean {
     let result = super.call("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_hasRole(role: Bytes, account: Address): ethereum.CallResult<boolean> {
     let result = super.tryCall("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   increaseAllowance(spender: Address, addedValue: BigInt): boolean {
@@ -356,122 +356,122 @@ export class SimpleToken extends ethereum.SmartContract {
       "increaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(addedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(addedValue)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_increaseAllowance(
     spender: Address,
-    addedValue: BigInt,
+    addedValue: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "increaseAllowance",
       "increaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(addedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(addedValue)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   name(): string {
-    let result = super.call("name", "name():(string)", [])
+    let result = super.call("name", "name():(string)", []);
 
-    return result[0].toString()
+    return result[0].toString();
   }
 
   try_name(): ethereum.CallResult<string> {
-    let result = super.tryCall("name", "name():(string)", [])
+    let result = super.tryCall("name", "name():(string)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toString())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toString());
   }
 
   supportsInterface(interfaceId: Bytes): boolean {
     let result = super.call(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_supportsInterface(interfaceId: Bytes): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   symbol(): string {
-    let result = super.call("symbol", "symbol():(string)", [])
+    let result = super.call("symbol", "symbol():(string)", []);
 
-    return result[0].toString()
+    return result[0].toString();
   }
 
   try_symbol(): ethereum.CallResult<string> {
-    let result = super.tryCall("symbol", "symbol():(string)", [])
+    let result = super.tryCall("symbol", "symbol():(string)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toString())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toString());
   }
 
   totalSupply(): BigInt {
-    let result = super.call("totalSupply", "totalSupply():(uint256)", [])
+    let result = super.call("totalSupply", "totalSupply():(uint256)", []);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_totalSupply(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall("totalSupply", "totalSupply():(uint256)", [])
+    let result = super.tryCall("totalSupply", "totalSupply():(uint256)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   transfer(recipient: Address, amount: BigInt): boolean {
     let result = super.call("transfer", "transfer(address,uint256):(bool)", [
       ethereum.Value.fromAddress(recipient),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_transfer(
     recipient: Address,
-    amount: BigInt,
+    amount: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall("transfer", "transfer(address,uint256):(bool)", [
       ethereum.Value.fromAddress(recipient),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   transferFrom(sender: Address, recipient: Address, amount: BigInt): boolean {
@@ -481,17 +481,17 @@ export class SimpleToken extends ethereum.SmartContract {
       [
         ethereum.Value.fromAddress(sender),
         ethereum.Value.fromAddress(recipient),
-        ethereum.Value.fromUnsignedBigInt(amount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(amount)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_transferFrom(
     sender: Address,
     recipient: Address,
-    amount: BigInt,
+    amount: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "transferFrom",
@@ -499,479 +499,479 @@ export class SimpleToken extends ethereum.SmartContract {
       [
         ethereum.Value.fromAddress(sender),
         ethereum.Value.fromAddress(recipient),
-        ethereum.Value.fromUnsignedBigInt(amount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(amount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 }
 
 export class ApproveCall extends ethereum.Call {
   get inputs(): ApproveCall__Inputs {
-    return new ApproveCall__Inputs(this)
+    return new ApproveCall__Inputs(this);
   }
 
   get outputs(): ApproveCall__Outputs {
-    return new ApproveCall__Outputs(this)
+    return new ApproveCall__Outputs(this);
   }
 }
 
 export class ApproveCall__Inputs {
-  _call: ApproveCall
+  _call: ApproveCall;
 
   constructor(call: ApproveCall) {
-    this._call = call
+    this._call = call;
   }
 
   get spender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class ApproveCall__Outputs {
-  _call: ApproveCall
+  _call: ApproveCall;
 
   constructor(call: ApproveCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class BurnCall extends ethereum.Call {
   get inputs(): BurnCall__Inputs {
-    return new BurnCall__Inputs(this)
+    return new BurnCall__Inputs(this);
   }
 
   get outputs(): BurnCall__Outputs {
-    return new BurnCall__Outputs(this)
+    return new BurnCall__Outputs(this);
   }
 }
 
 export class BurnCall__Inputs {
-  _call: BurnCall
+  _call: BurnCall;
 
   constructor(call: BurnCall) {
-    this._call = call
+    this._call = call;
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 }
 
 export class BurnCall__Outputs {
-  _call: BurnCall
+  _call: BurnCall;
 
   constructor(call: BurnCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class Burn1Call extends ethereum.Call {
   get inputs(): Burn1Call__Inputs {
-    return new Burn1Call__Inputs(this)
+    return new Burn1Call__Inputs(this);
   }
 
   get outputs(): Burn1Call__Outputs {
-    return new Burn1Call__Outputs(this)
+    return new Burn1Call__Outputs(this);
   }
 }
 
 export class Burn1Call__Inputs {
-  _call: Burn1Call
+  _call: Burn1Call;
 
   constructor(call: Burn1Call) {
-    this._call = call
+    this._call = call;
   }
 
   get account(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class Burn1Call__Outputs {
-  _call: Burn1Call
+  _call: Burn1Call;
 
   constructor(call: Burn1Call) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class BurnFromCall extends ethereum.Call {
   get inputs(): BurnFromCall__Inputs {
-    return new BurnFromCall__Inputs(this)
+    return new BurnFromCall__Inputs(this);
   }
 
   get outputs(): BurnFromCall__Outputs {
-    return new BurnFromCall__Outputs(this)
+    return new BurnFromCall__Outputs(this);
   }
 }
 
 export class BurnFromCall__Inputs {
-  _call: BurnFromCall
+  _call: BurnFromCall;
 
   constructor(call: BurnFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get account(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class BurnFromCall__Outputs {
-  _call: BurnFromCall
+  _call: BurnFromCall;
 
   constructor(call: BurnFromCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class DecreaseAllowanceCall extends ethereum.Call {
   get inputs(): DecreaseAllowanceCall__Inputs {
-    return new DecreaseAllowanceCall__Inputs(this)
+    return new DecreaseAllowanceCall__Inputs(this);
   }
 
   get outputs(): DecreaseAllowanceCall__Outputs {
-    return new DecreaseAllowanceCall__Outputs(this)
+    return new DecreaseAllowanceCall__Outputs(this);
   }
 }
 
 export class DecreaseAllowanceCall__Inputs {
-  _call: DecreaseAllowanceCall
+  _call: DecreaseAllowanceCall;
 
   constructor(call: DecreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get spender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get subtractedValue(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class DecreaseAllowanceCall__Outputs {
-  _call: DecreaseAllowanceCall
+  _call: DecreaseAllowanceCall;
 
   constructor(call: DecreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class GrantRoleCall extends ethereum.Call {
   get inputs(): GrantRoleCall__Inputs {
-    return new GrantRoleCall__Inputs(this)
+    return new GrantRoleCall__Inputs(this);
   }
 
   get outputs(): GrantRoleCall__Outputs {
-    return new GrantRoleCall__Outputs(this)
+    return new GrantRoleCall__Outputs(this);
   }
 }
 
 export class GrantRoleCall__Inputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class GrantRoleCall__Outputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class IncreaseAllowanceCall extends ethereum.Call {
   get inputs(): IncreaseAllowanceCall__Inputs {
-    return new IncreaseAllowanceCall__Inputs(this)
+    return new IncreaseAllowanceCall__Inputs(this);
   }
 
   get outputs(): IncreaseAllowanceCall__Outputs {
-    return new IncreaseAllowanceCall__Outputs(this)
+    return new IncreaseAllowanceCall__Outputs(this);
   }
 }
 
 export class IncreaseAllowanceCall__Inputs {
-  _call: IncreaseAllowanceCall
+  _call: IncreaseAllowanceCall;
 
   constructor(call: IncreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get spender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get addedValue(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class IncreaseAllowanceCall__Outputs {
-  _call: IncreaseAllowanceCall
+  _call: IncreaseAllowanceCall;
 
   constructor(call: IncreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class InitializeCall extends ethereum.Call {
   get inputs(): InitializeCall__Inputs {
-    return new InitializeCall__Inputs(this)
+    return new InitializeCall__Inputs(this);
   }
 
   get outputs(): InitializeCall__Outputs {
-    return new InitializeCall__Outputs(this)
+    return new InitializeCall__Outputs(this);
   }
 }
 
 export class InitializeCall__Inputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _name(): string {
-    return this._call.inputValues[0].value.toString()
+    return this._call.inputValues[0].value.toString();
   }
 
   get _symbol(): string {
-    return this._call.inputValues[1].value.toString()
+    return this._call.inputValues[1].value.toString();
   }
 
   get _decimals(): i32 {
-    return this._call.inputValues[2].value.toI32()
+    return this._call.inputValues[2].value.toI32();
   }
 }
 
 export class InitializeCall__Outputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class MintCall extends ethereum.Call {
   get inputs(): MintCall__Inputs {
-    return new MintCall__Inputs(this)
+    return new MintCall__Inputs(this);
   }
 
   get outputs(): MintCall__Outputs {
-    return new MintCall__Outputs(this)
+    return new MintCall__Outputs(this);
   }
 }
 
 export class MintCall__Inputs {
-  _call: MintCall
+  _call: MintCall;
 
   constructor(call: MintCall) {
-    this._call = call
+    this._call = call;
   }
 
   get to(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class MintCall__Outputs {
-  _call: MintCall
+  _call: MintCall;
 
   constructor(call: MintCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceRoleCall extends ethereum.Call {
   get inputs(): RenounceRoleCall__Inputs {
-    return new RenounceRoleCall__Inputs(this)
+    return new RenounceRoleCall__Inputs(this);
   }
 
   get outputs(): RenounceRoleCall__Outputs {
-    return new RenounceRoleCall__Outputs(this)
+    return new RenounceRoleCall__Outputs(this);
   }
 }
 
 export class RenounceRoleCall__Inputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RenounceRoleCall__Outputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RevokeRoleCall extends ethereum.Call {
   get inputs(): RevokeRoleCall__Inputs {
-    return new RevokeRoleCall__Inputs(this)
+    return new RevokeRoleCall__Inputs(this);
   }
 
   get outputs(): RevokeRoleCall__Outputs {
-    return new RevokeRoleCall__Outputs(this)
+    return new RevokeRoleCall__Outputs(this);
   }
 }
 
 export class RevokeRoleCall__Inputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RevokeRoleCall__Outputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class TransferCall extends ethereum.Call {
   get inputs(): TransferCall__Inputs {
-    return new TransferCall__Inputs(this)
+    return new TransferCall__Inputs(this);
   }
 
   get outputs(): TransferCall__Outputs {
-    return new TransferCall__Outputs(this)
+    return new TransferCall__Outputs(this);
   }
 }
 
 export class TransferCall__Inputs {
-  _call: TransferCall
+  _call: TransferCall;
 
   constructor(call: TransferCall) {
-    this._call = call
+    this._call = call;
   }
 
   get recipient(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class TransferCall__Outputs {
-  _call: TransferCall
+  _call: TransferCall;
 
   constructor(call: TransferCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class TransferFromCall extends ethereum.Call {
   get inputs(): TransferFromCall__Inputs {
-    return new TransferFromCall__Inputs(this)
+    return new TransferFromCall__Inputs(this);
   }
 
   get outputs(): TransferFromCall__Outputs {
-    return new TransferFromCall__Outputs(this)
+    return new TransferFromCall__Outputs(this);
   }
 }
 
 export class TransferFromCall__Inputs {
-  _call: TransferFromCall
+  _call: TransferFromCall;
 
   constructor(call: TransferFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get sender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get recipient(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 }
 
 export class TransferFromCall__Outputs {
-  _call: TransferFromCall
+  _call: TransferFromCall;
 
   constructor(call: TransferFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }

--- a/subgraph/generated/SeriesVault/SeriesVault.ts
+++ b/subgraph/generated/SeriesVault/SeriesVault.ts
@@ -7,93 +7,93 @@ import {
   Entity,
   Bytes,
   Address,
-  BigInt,
-} from "@graphprotocol/graph-ts"
+  BigInt
+} from "@graphprotocol/graph-ts";
 
 export class CodeAddressUpdated extends ethereum.Event {
   get params(): CodeAddressUpdated__Params {
-    return new CodeAddressUpdated__Params(this)
+    return new CodeAddressUpdated__Params(this);
   }
 }
 
 export class CodeAddressUpdated__Params {
-  _event: CodeAddressUpdated
+  _event: CodeAddressUpdated;
 
   constructor(event: CodeAddressUpdated) {
-    this._event = event
+    this._event = event;
   }
 
   get newAddress(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class OwnershipTransferred extends ethereum.Event {
   get params(): OwnershipTransferred__Params {
-    return new OwnershipTransferred__Params(this)
+    return new OwnershipTransferred__Params(this);
   }
 }
 
 export class OwnershipTransferred__Params {
-  _event: OwnershipTransferred
+  _event: OwnershipTransferred;
 
   constructor(event: OwnershipTransferred) {
-    this._event = event
+    this._event = event;
   }
 
   get previousOwner(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get newOwner(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 }
 
 export class SeriesVaultInitialized extends ethereum.Event {
   get params(): SeriesVaultInitialized__Params {
-    return new SeriesVaultInitialized__Params(this)
+    return new SeriesVaultInitialized__Params(this);
   }
 }
 
 export class SeriesVaultInitialized__Params {
-  _event: SeriesVaultInitialized
+  _event: SeriesVaultInitialized;
 
   constructor(event: SeriesVaultInitialized) {
-    this._event = event
+    this._event = event;
   }
 
   get controller(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class SeriesVault extends ethereum.SmartContract {
   static bind(address: Address): SeriesVault {
-    return new SeriesVault("SeriesVault", address)
+    return new SeriesVault("SeriesVault", address);
   }
 
   getLogicAddress(): Address {
     let result = super.call(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_getLogicAddress(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   onERC1155BatchReceived(
@@ -101,7 +101,7 @@ export class SeriesVault extends ethereum.SmartContract {
     param1: Address,
     param2: Array<BigInt>,
     param3: Array<BigInt>,
-    param4: Bytes,
+    param4: Bytes
   ): Bytes {
     let result = super.call(
       "onERC1155BatchReceived",
@@ -111,11 +111,11 @@ export class SeriesVault extends ethereum.SmartContract {
         ethereum.Value.fromAddress(param1),
         ethereum.Value.fromUnsignedBigIntArray(param2),
         ethereum.Value.fromUnsignedBigIntArray(param3),
-        ethereum.Value.fromBytes(param4),
-      ],
-    )
+        ethereum.Value.fromBytes(param4)
+      ]
+    );
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_onERC1155BatchReceived(
@@ -123,7 +123,7 @@ export class SeriesVault extends ethereum.SmartContract {
     param1: Address,
     param2: Array<BigInt>,
     param3: Array<BigInt>,
-    param4: Bytes,
+    param4: Bytes
   ): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "onERC1155BatchReceived",
@@ -133,14 +133,14 @@ export class SeriesVault extends ethereum.SmartContract {
         ethereum.Value.fromAddress(param1),
         ethereum.Value.fromUnsignedBigIntArray(param2),
         ethereum.Value.fromUnsignedBigIntArray(param3),
-        ethereum.Value.fromBytes(param4),
-      ],
-    )
+        ethereum.Value.fromBytes(param4)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   onERC1155Received(
@@ -148,7 +148,7 @@ export class SeriesVault extends ethereum.SmartContract {
     param1: Address,
     param2: BigInt,
     param3: BigInt,
-    param4: Bytes,
+    param4: Bytes
   ): Bytes {
     let result = super.call(
       "onERC1155Received",
@@ -158,11 +158,11 @@ export class SeriesVault extends ethereum.SmartContract {
         ethereum.Value.fromAddress(param1),
         ethereum.Value.fromUnsignedBigInt(param2),
         ethereum.Value.fromUnsignedBigInt(param3),
-        ethereum.Value.fromBytes(param4),
-      ],
-    )
+        ethereum.Value.fromBytes(param4)
+      ]
+    );
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_onERC1155Received(
@@ -170,7 +170,7 @@ export class SeriesVault extends ethereum.SmartContract {
     param1: Address,
     param2: BigInt,
     param3: BigInt,
-    param4: Bytes,
+    param4: Bytes
   ): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "onERC1155Received",
@@ -180,371 +180,375 @@ export class SeriesVault extends ethereum.SmartContract {
         ethereum.Value.fromAddress(param1),
         ethereum.Value.fromUnsignedBigInt(param2),
         ethereum.Value.fromUnsignedBigInt(param3),
-        ethereum.Value.fromBytes(param4),
-      ],
-    )
+        ethereum.Value.fromBytes(param4)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   owner(): Address {
-    let result = super.call("owner", "owner():(address)", [])
+    let result = super.call("owner", "owner():(address)", []);
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_owner(): ethereum.CallResult<Address> {
-    let result = super.tryCall("owner", "owner():(address)", [])
+    let result = super.tryCall("owner", "owner():(address)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   proxiableUUID(): Bytes {
-    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_proxiableUUID(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.tryCall(
+      "proxiableUUID",
+      "proxiableUUID():(bytes32)",
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   setERC1155ApprovalForController(erc1155Contract: Address): boolean {
     let result = super.call(
       "setERC1155ApprovalForController",
       "setERC1155ApprovalForController(address):(bool)",
-      [ethereum.Value.fromAddress(erc1155Contract)],
-    )
+      [ethereum.Value.fromAddress(erc1155Contract)]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_setERC1155ApprovalForController(
-    erc1155Contract: Address,
+    erc1155Contract: Address
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "setERC1155ApprovalForController",
       "setERC1155ApprovalForController(address):(bool)",
-      [ethereum.Value.fromAddress(erc1155Contract)],
-    )
+      [ethereum.Value.fromAddress(erc1155Contract)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   supportsInterface(interfaceId: Bytes): boolean {
     let result = super.call(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_supportsInterface(interfaceId: Bytes): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 }
 
 export class __SeriesVault_initCall extends ethereum.Call {
   get inputs(): __SeriesVault_initCall__Inputs {
-    return new __SeriesVault_initCall__Inputs(this)
+    return new __SeriesVault_initCall__Inputs(this);
   }
 
   get outputs(): __SeriesVault_initCall__Outputs {
-    return new __SeriesVault_initCall__Outputs(this)
+    return new __SeriesVault_initCall__Outputs(this);
   }
 }
 
 export class __SeriesVault_initCall__Inputs {
-  _call: __SeriesVault_initCall
+  _call: __SeriesVault_initCall;
 
   constructor(call: __SeriesVault_initCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _seriesController(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class __SeriesVault_initCall__Outputs {
-  _call: __SeriesVault_initCall
+  _call: __SeriesVault_initCall;
 
   constructor(call: __SeriesVault_initCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class OnERC1155BatchReceivedCall extends ethereum.Call {
   get inputs(): OnERC1155BatchReceivedCall__Inputs {
-    return new OnERC1155BatchReceivedCall__Inputs(this)
+    return new OnERC1155BatchReceivedCall__Inputs(this);
   }
 
   get outputs(): OnERC1155BatchReceivedCall__Outputs {
-    return new OnERC1155BatchReceivedCall__Outputs(this)
+    return new OnERC1155BatchReceivedCall__Outputs(this);
   }
 }
 
 export class OnERC1155BatchReceivedCall__Inputs {
-  _call: OnERC1155BatchReceivedCall
+  _call: OnERC1155BatchReceivedCall;
 
   constructor(call: OnERC1155BatchReceivedCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get value1(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get value2(): Array<BigInt> {
-    return this._call.inputValues[2].value.toBigIntArray()
+    return this._call.inputValues[2].value.toBigIntArray();
   }
 
   get value3(): Array<BigInt> {
-    return this._call.inputValues[3].value.toBigIntArray()
+    return this._call.inputValues[3].value.toBigIntArray();
   }
 
   get value4(): Bytes {
-    return this._call.inputValues[4].value.toBytes()
+    return this._call.inputValues[4].value.toBytes();
   }
 }
 
 export class OnERC1155BatchReceivedCall__Outputs {
-  _call: OnERC1155BatchReceivedCall
+  _call: OnERC1155BatchReceivedCall;
 
   constructor(call: OnERC1155BatchReceivedCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): Bytes {
-    return this._call.outputValues[0].value.toBytes()
+    return this._call.outputValues[0].value.toBytes();
   }
 }
 
 export class OnERC1155ReceivedCall extends ethereum.Call {
   get inputs(): OnERC1155ReceivedCall__Inputs {
-    return new OnERC1155ReceivedCall__Inputs(this)
+    return new OnERC1155ReceivedCall__Inputs(this);
   }
 
   get outputs(): OnERC1155ReceivedCall__Outputs {
-    return new OnERC1155ReceivedCall__Outputs(this)
+    return new OnERC1155ReceivedCall__Outputs(this);
   }
 }
 
 export class OnERC1155ReceivedCall__Inputs {
-  _call: OnERC1155ReceivedCall
+  _call: OnERC1155ReceivedCall;
 
   constructor(call: OnERC1155ReceivedCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get value1(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get value2(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 
   get value3(): BigInt {
-    return this._call.inputValues[3].value.toBigInt()
+    return this._call.inputValues[3].value.toBigInt();
   }
 
   get value4(): Bytes {
-    return this._call.inputValues[4].value.toBytes()
+    return this._call.inputValues[4].value.toBytes();
   }
 }
 
 export class OnERC1155ReceivedCall__Outputs {
-  _call: OnERC1155ReceivedCall
+  _call: OnERC1155ReceivedCall;
 
   constructor(call: OnERC1155ReceivedCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): Bytes {
-    return this._call.outputValues[0].value.toBytes()
+    return this._call.outputValues[0].value.toBytes();
   }
 }
 
 export class RenounceOwnershipCall extends ethereum.Call {
   get inputs(): RenounceOwnershipCall__Inputs {
-    return new RenounceOwnershipCall__Inputs(this)
+    return new RenounceOwnershipCall__Inputs(this);
   }
 
   get outputs(): RenounceOwnershipCall__Outputs {
-    return new RenounceOwnershipCall__Outputs(this)
+    return new RenounceOwnershipCall__Outputs(this);
   }
 }
 
 export class RenounceOwnershipCall__Inputs {
-  _call: RenounceOwnershipCall
+  _call: RenounceOwnershipCall;
 
   constructor(call: RenounceOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceOwnershipCall__Outputs {
-  _call: RenounceOwnershipCall
+  _call: RenounceOwnershipCall;
 
   constructor(call: RenounceOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class SetERC1155ApprovalForControllerCall extends ethereum.Call {
   get inputs(): SetERC1155ApprovalForControllerCall__Inputs {
-    return new SetERC1155ApprovalForControllerCall__Inputs(this)
+    return new SetERC1155ApprovalForControllerCall__Inputs(this);
   }
 
   get outputs(): SetERC1155ApprovalForControllerCall__Outputs {
-    return new SetERC1155ApprovalForControllerCall__Outputs(this)
+    return new SetERC1155ApprovalForControllerCall__Outputs(this);
   }
 }
 
 export class SetERC1155ApprovalForControllerCall__Inputs {
-  _call: SetERC1155ApprovalForControllerCall
+  _call: SetERC1155ApprovalForControllerCall;
 
   constructor(call: SetERC1155ApprovalForControllerCall) {
-    this._call = call
+    this._call = call;
   }
 
   get erc1155Contract(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class SetERC1155ApprovalForControllerCall__Outputs {
-  _call: SetERC1155ApprovalForControllerCall
+  _call: SetERC1155ApprovalForControllerCall;
 
   constructor(call: SetERC1155ApprovalForControllerCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class SetERC20ApprovalForControllerCall extends ethereum.Call {
   get inputs(): SetERC20ApprovalForControllerCall__Inputs {
-    return new SetERC20ApprovalForControllerCall__Inputs(this)
+    return new SetERC20ApprovalForControllerCall__Inputs(this);
   }
 
   get outputs(): SetERC20ApprovalForControllerCall__Outputs {
-    return new SetERC20ApprovalForControllerCall__Outputs(this)
+    return new SetERC20ApprovalForControllerCall__Outputs(this);
   }
 }
 
 export class SetERC20ApprovalForControllerCall__Inputs {
-  _call: SetERC20ApprovalForControllerCall
+  _call: SetERC20ApprovalForControllerCall;
 
   constructor(call: SetERC20ApprovalForControllerCall) {
-    this._call = call
+    this._call = call;
   }
 
   get erc20Token(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class SetERC20ApprovalForControllerCall__Outputs {
-  _call: SetERC20ApprovalForControllerCall
+  _call: SetERC20ApprovalForControllerCall;
 
   constructor(call: SetERC20ApprovalForControllerCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class TransferOwnershipCall extends ethereum.Call {
   get inputs(): TransferOwnershipCall__Inputs {
-    return new TransferOwnershipCall__Inputs(this)
+    return new TransferOwnershipCall__Inputs(this);
   }
 
   get outputs(): TransferOwnershipCall__Outputs {
-    return new TransferOwnershipCall__Outputs(this)
+    return new TransferOwnershipCall__Outputs(this);
   }
 }
 
 export class TransferOwnershipCall__Inputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 
   get newOwner(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class TransferOwnershipCall__Outputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UpdateImplementationCall extends ethereum.Call {
   get inputs(): UpdateImplementationCall__Inputs {
-    return new UpdateImplementationCall__Inputs(this)
+    return new UpdateImplementationCall__Inputs(this);
   }
 
   get outputs(): UpdateImplementationCall__Outputs {
-    return new UpdateImplementationCall__Outputs(this)
+    return new UpdateImplementationCall__Outputs(this);
   }
 }
 
 export class UpdateImplementationCall__Inputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _newImplementation(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class UpdateImplementationCall__Outputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 }

--- a/subgraph/generated/schema.ts
+++ b/subgraph/generated/schema.ts
@@ -9,3659 +9,3689 @@ import {
   Address,
   Bytes,
   BigInt,
-  BigDecimal,
-} from "@graphprotocol/graph-ts"
+  BigDecimal
+} from "@graphprotocol/graph-ts";
 
 export class SeriesController extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save SeriesController entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save SeriesController entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save SeriesController entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("SeriesController", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("SeriesController", id.toString(), this);
   }
 
   static load(id: string): SeriesController | null {
-    return store.get("SeriesController", id) as SeriesController | null
+    return store.get("SeriesController", id) as SeriesController | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get createdBlock(): BigInt {
-    let value = this.get("createdBlock")
-    return value.toBigInt()
+    let value = this.get("createdBlock");
+    return value.toBigInt();
   }
 
   set createdBlock(value: BigInt) {
-    this.set("createdBlock", Value.fromBigInt(value))
+    this.set("createdBlock", Value.fromBigInt(value));
   }
 
   get createdTimestamp(): BigInt {
-    let value = this.get("createdTimestamp")
-    return value.toBigInt()
+    let value = this.get("createdTimestamp");
+    return value.toBigInt();
   }
 
   set createdTimestamp(value: BigInt) {
-    this.set("createdTimestamp", Value.fromBigInt(value))
+    this.set("createdTimestamp", Value.fromBigInt(value));
   }
 
   get createdTransaction(): Bytes {
-    let value = this.get("createdTransaction")
-    return value.toBytes()
+    let value = this.get("createdTransaction");
+    return value.toBytes();
   }
 
   set createdTransaction(value: Bytes) {
-    this.set("createdTransaction", Value.fromBytes(value))
+    this.set("createdTransaction", Value.fromBytes(value));
   }
 
   get lastUpdatedBlock(): BigInt {
-    let value = this.get("lastUpdatedBlock")
-    return value.toBigInt()
+    let value = this.get("lastUpdatedBlock");
+    return value.toBigInt();
   }
 
   set lastUpdatedBlock(value: BigInt) {
-    this.set("lastUpdatedBlock", Value.fromBigInt(value))
+    this.set("lastUpdatedBlock", Value.fromBigInt(value));
   }
 
   get lastUpdatedTimestamp(): BigInt {
-    let value = this.get("lastUpdatedTimestamp")
-    return value.toBigInt()
+    let value = this.get("lastUpdatedTimestamp");
+    return value.toBigInt();
   }
 
   set lastUpdatedTimestamp(value: BigInt) {
-    this.set("lastUpdatedTimestamp", Value.fromBigInt(value))
+    this.set("lastUpdatedTimestamp", Value.fromBigInt(value));
   }
 
   get lastUpdatedTransaction(): Bytes {
-    let value = this.get("lastUpdatedTransaction")
-    return value.toBytes()
+    let value = this.get("lastUpdatedTransaction");
+    return value.toBytes();
   }
 
   set lastUpdatedTransaction(value: Bytes) {
-    this.set("lastUpdatedTransaction", Value.fromBytes(value))
+    this.set("lastUpdatedTransaction", Value.fromBytes(value));
   }
 
   get priceOracle(): Bytes {
-    let value = this.get("priceOracle")
-    return value.toBytes()
+    let value = this.get("priceOracle");
+    return value.toBytes();
   }
 
   set priceOracle(value: Bytes) {
-    this.set("priceOracle", Value.fromBytes(value))
+    this.set("priceOracle", Value.fromBytes(value));
   }
 
   get vault(): string {
-    let value = this.get("vault")
-    return value.toString()
+    let value = this.get("vault");
+    return value.toString();
   }
 
   set vault(value: string) {
-    this.set("vault", Value.fromString(value))
+    this.set("vault", Value.fromString(value));
   }
 
   get erc1155Controller(): Bytes {
-    let value = this.get("erc1155Controller")
-    return value.toBytes()
+    let value = this.get("erc1155Controller");
+    return value.toBytes();
   }
 
   set erc1155Controller(value: Bytes) {
-    this.set("erc1155Controller", Value.fromBytes(value))
+    this.set("erc1155Controller", Value.fromBytes(value));
   }
 
   get feeReceiver(): Bytes {
-    let value = this.get("feeReceiver")
-    return value.toBytes()
+    let value = this.get("feeReceiver");
+    return value.toBytes();
   }
 
   set feeReceiver(value: Bytes) {
-    this.set("feeReceiver", Value.fromBytes(value))
+    this.set("feeReceiver", Value.fromBytes(value));
   }
 
   get exerciseFeeBasisPoints(): i32 {
-    let value = this.get("exerciseFeeBasisPoints")
-    return value.toI32()
+    let value = this.get("exerciseFeeBasisPoints");
+    return value.toI32();
   }
 
   set exerciseFeeBasisPoints(value: i32) {
-    this.set("exerciseFeeBasisPoints", Value.fromI32(value))
+    this.set("exerciseFeeBasisPoints", Value.fromI32(value));
   }
 
   get closeFeeBasisPoints(): i32 {
-    let value = this.get("closeFeeBasisPoints")
-    return value.toI32()
+    let value = this.get("closeFeeBasisPoints");
+    return value.toI32();
   }
 
   set closeFeeBasisPoints(value: i32) {
-    this.set("closeFeeBasisPoints", Value.fromI32(value))
+    this.set("closeFeeBasisPoints", Value.fromI32(value));
   }
 
   get claimFeeBasisPoints(): i32 {
-    let value = this.get("claimFeeBasisPoints")
-    return value.toI32()
+    let value = this.get("claimFeeBasisPoints");
+    return value.toI32();
   }
 
   set claimFeeBasisPoints(value: i32) {
-    this.set("claimFeeBasisPoints", Value.fromI32(value))
+    this.set("claimFeeBasisPoints", Value.fromI32(value));
   }
 }
 
 export class ERC20VaultTransfer extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save ERC20VaultTransfer entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save ERC20VaultTransfer entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC20VaultTransfer entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC20VaultTransfer", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC20VaultTransfer", id.toString(), this);
   }
 
   static load(id: string): ERC20VaultTransfer | null {
-    return store.get("ERC20VaultTransfer", id) as ERC20VaultTransfer | null
+    return store.get("ERC20VaultTransfer", id) as ERC20VaultTransfer | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get createdBlock(): BigInt {
-    let value = this.get("createdBlock")
-    return value.toBigInt()
+    let value = this.get("createdBlock");
+    return value.toBigInt();
   }
 
   set createdBlock(value: BigInt) {
-    this.set("createdBlock", Value.fromBigInt(value))
+    this.set("createdBlock", Value.fromBigInt(value));
   }
 
   get createdTimestamp(): BigInt {
-    let value = this.get("createdTimestamp")
-    return value.toBigInt()
+    let value = this.get("createdTimestamp");
+    return value.toBigInt();
   }
 
   set createdTimestamp(value: BigInt) {
-    this.set("createdTimestamp", Value.fromBigInt(value))
+    this.set("createdTimestamp", Value.fromBigInt(value));
   }
 
   get createdTransaction(): Bytes {
-    let value = this.get("createdTransaction")
-    return value.toBytes()
+    let value = this.get("createdTransaction");
+    return value.toBytes();
   }
 
   set createdTransaction(value: Bytes) {
-    this.set("createdTransaction", Value.fromBytes(value))
+    this.set("createdTransaction", Value.fromBytes(value));
   }
 }
 
 export class SeriesEntity extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save SeriesEntity entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save SeriesEntity entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save SeriesEntity entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("SeriesEntity", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("SeriesEntity", id.toString(), this);
   }
 
   static load(id: string): SeriesEntity | null {
-    return store.get("SeriesEntity", id) as SeriesEntity | null
+    return store.get("SeriesEntity", id) as SeriesEntity | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get createdBlock(): BigInt {
-    let value = this.get("createdBlock")
-    return value.toBigInt()
+    let value = this.get("createdBlock");
+    return value.toBigInt();
   }
 
   set createdBlock(value: BigInt) {
-    this.set("createdBlock", Value.fromBigInt(value))
+    this.set("createdBlock", Value.fromBigInt(value));
   }
 
   get createdTimestamp(): BigInt {
-    let value = this.get("createdTimestamp")
-    return value.toBigInt()
+    let value = this.get("createdTimestamp");
+    return value.toBigInt();
   }
 
   set createdTimestamp(value: BigInt) {
-    this.set("createdTimestamp", Value.fromBigInt(value))
+    this.set("createdTimestamp", Value.fromBigInt(value));
   }
 
   get createdTransaction(): Bytes {
-    let value = this.get("createdTransaction")
-    return value.toBytes()
+    let value = this.get("createdTransaction");
+    return value.toBytes();
   }
 
   set createdTransaction(value: Bytes) {
-    this.set("createdTransaction", Value.fromBytes(value))
+    this.set("createdTransaction", Value.fromBytes(value));
   }
 
   get seriesName(): string {
-    let value = this.get("seriesName")
-    return value.toString()
+    let value = this.get("seriesName");
+    return value.toString();
   }
 
   set seriesName(value: string) {
-    this.set("seriesName", Value.fromString(value))
+    this.set("seriesName", Value.fromString(value));
   }
 
   get seriesId(): BigInt {
-    let value = this.get("seriesId")
-    return value.toBigInt()
+    let value = this.get("seriesId");
+    return value.toBigInt();
   }
 
   set seriesId(value: BigInt) {
-    this.set("seriesId", Value.fromBigInt(value))
+    this.set("seriesId", Value.fromBigInt(value));
   }
 
   get underlyingToken(): string {
-    let value = this.get("underlyingToken")
-    return value.toString()
+    let value = this.get("underlyingToken");
+    return value.toString();
   }
 
   set underlyingToken(value: string) {
-    this.set("underlyingToken", Value.fromString(value))
+    this.set("underlyingToken", Value.fromString(value));
   }
 
   get priceToken(): string {
-    let value = this.get("priceToken")
-    return value.toString()
+    let value = this.get("priceToken");
+    return value.toString();
   }
 
   set priceToken(value: string) {
-    this.set("priceToken", Value.fromString(value))
+    this.set("priceToken", Value.fromString(value));
   }
 
   get collateralToken(): string {
-    let value = this.get("collateralToken")
-    return value.toString()
+    let value = this.get("collateralToken");
+    return value.toString();
   }
 
   set collateralToken(value: string) {
-    this.set("collateralToken", Value.fromString(value))
+    this.set("collateralToken", Value.fromString(value));
   }
 
   get isPutOption(): boolean {
-    let value = this.get("isPutOption")
-    return value.toBoolean()
+    let value = this.get("isPutOption");
+    return value.toBoolean();
   }
 
   set isPutOption(value: boolean) {
-    this.set("isPutOption", Value.fromBoolean(value))
+    this.set("isPutOption", Value.fromBoolean(value));
   }
 
   get strikePrice(): BigInt {
-    let value = this.get("strikePrice")
-    return value.toBigInt()
+    let value = this.get("strikePrice");
+    return value.toBigInt();
   }
 
   set strikePrice(value: BigInt) {
-    this.set("strikePrice", Value.fromBigInt(value))
+    this.set("strikePrice", Value.fromBigInt(value));
   }
 
   get expirationDate(): BigInt {
-    let value = this.get("expirationDate")
-    return value.toBigInt()
+    let value = this.get("expirationDate");
+    return value.toBigInt();
   }
 
   set expirationDate(value: BigInt) {
-    this.set("expirationDate", Value.fromBigInt(value))
+    this.set("expirationDate", Value.fromBigInt(value));
   }
 
   get exerciseFeeBasisPoints(): i32 {
-    let value = this.get("exerciseFeeBasisPoints")
-    return value.toI32()
+    let value = this.get("exerciseFeeBasisPoints");
+    return value.toI32();
   }
 
   set exerciseFeeBasisPoints(value: i32) {
-    this.set("exerciseFeeBasisPoints", Value.fromI32(value))
+    this.set("exerciseFeeBasisPoints", Value.fromI32(value));
   }
 
   get closeFeeBasisPoints(): i32 {
-    let value = this.get("closeFeeBasisPoints")
-    return value.toI32()
+    let value = this.get("closeFeeBasisPoints");
+    return value.toI32();
   }
 
   set closeFeeBasisPoints(value: i32) {
-    this.set("closeFeeBasisPoints", Value.fromI32(value))
+    this.set("closeFeeBasisPoints", Value.fromI32(value));
   }
 
   get claimFeeBasisPoints(): i32 {
-    let value = this.get("claimFeeBasisPoints")
-    return value.toI32()
+    let value = this.get("claimFeeBasisPoints");
+    return value.toI32();
   }
 
   set claimFeeBasisPoints(value: i32) {
-    this.set("claimFeeBasisPoints", Value.fromI32(value))
+    this.set("claimFeeBasisPoints", Value.fromI32(value));
   }
 
   get priceOracle(): Bytes {
-    let value = this.get("priceOracle")
-    return value.toBytes()
+    let value = this.get("priceOracle");
+    return value.toBytes();
   }
 
   set priceOracle(value: Bytes) {
-    this.set("priceOracle", Value.fromBytes(value))
+    this.set("priceOracle", Value.fromBytes(value));
   }
 
   get wToken(): string {
-    let value = this.get("wToken")
-    return value.toString()
+    let value = this.get("wToken");
+    return value.toString();
   }
 
   set wToken(value: string) {
-    this.set("wToken", Value.fromString(value))
+    this.set("wToken", Value.fromString(value));
   }
 
   get bToken(): string {
-    let value = this.get("bToken")
-    return value.toString()
+    let value = this.get("bToken");
+    return value.toString();
   }
 
   set bToken(value: string) {
-    this.set("bToken", Value.fromString(value))
+    this.set("bToken", Value.fromString(value));
   }
 
   get restrictedMinters(): Array<string> {
-    let value = this.get("restrictedMinters")
-    return value.toStringArray()
+    let value = this.get("restrictedMinters");
+    return value.toStringArray();
   }
 
   set restrictedMinters(value: Array<string>) {
-    this.set("restrictedMinters", Value.fromStringArray(value))
+    this.set("restrictedMinters", Value.fromStringArray(value));
   }
 
   get events(): Array<string> {
-    let value = this.get("events")
-    return value.toStringArray()
+    let value = this.get("events");
+    return value.toStringArray();
   }
 
   set events(value: Array<string>) {
-    this.set("events", Value.fromStringArray(value))
+    this.set("events", Value.fromStringArray(value));
   }
 }
 
 export class Amm extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save Amm entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save Amm entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save Amm entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("Amm", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("Amm", id.toString(), this);
   }
 
   static load(id: string): Amm | null {
-    return store.get("Amm", id) as Amm | null
+    return store.get("Amm", id) as Amm | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get createdBlock(): BigInt {
-    let value = this.get("createdBlock")
-    return value.toBigInt()
+    let value = this.get("createdBlock");
+    return value.toBigInt();
   }
 
   set createdBlock(value: BigInt) {
-    this.set("createdBlock", Value.fromBigInt(value))
+    this.set("createdBlock", Value.fromBigInt(value));
   }
 
   get createdTimestamp(): BigInt {
-    let value = this.get("createdTimestamp")
-    return value.toBigInt()
+    let value = this.get("createdTimestamp");
+    return value.toBigInt();
   }
 
   set createdTimestamp(value: BigInt) {
-    this.set("createdTimestamp", Value.fromBigInt(value))
+    this.set("createdTimestamp", Value.fromBigInt(value));
   }
 
   get createdTransaction(): Bytes {
-    let value = this.get("createdTransaction")
-    return value.toBytes()
+    let value = this.get("createdTransaction");
+    return value.toBytes();
   }
 
   set createdTransaction(value: Bytes) {
-    this.set("createdTransaction", Value.fromBytes(value))
+    this.set("createdTransaction", Value.fromBytes(value));
   }
 
   get series(): Array<string | null> {
-    let value = this.get("series")
-    return value.toStringArray()
+    let value = this.get("series");
+    return value.toStringArray();
   }
 
   set series(value: Array<string | null>) {
-    this.set("series", Value.fromStringArray(value))
+    this.set("series", Value.fromStringArray(value));
   }
 
   get controller(): string {
-    let value = this.get("controller")
-    return value.toString()
+    let value = this.get("controller");
+    return value.toString();
   }
 
   set controller(value: string) {
-    this.set("controller", Value.fromString(value))
+    this.set("controller", Value.fromString(value));
   }
 
   get priceOracle(): Bytes {
-    let value = this.get("priceOracle")
-    return value.toBytes()
+    let value = this.get("priceOracle");
+    return value.toBytes();
   }
 
   set priceOracle(value: Bytes) {
-    this.set("priceOracle", Value.fromBytes(value))
+    this.set("priceOracle", Value.fromBytes(value));
   }
 
   get underlyingToken(): string {
-    let value = this.get("underlyingToken")
-    return value.toString()
+    let value = this.get("underlyingToken");
+    return value.toString();
   }
 
   set underlyingToken(value: string) {
-    this.set("underlyingToken", Value.fromString(value))
+    this.set("underlyingToken", Value.fromString(value));
   }
 
   get priceToken(): string {
-    let value = this.get("priceToken")
-    return value.toString()
+    let value = this.get("priceToken");
+    return value.toString();
   }
 
   set priceToken(value: string) {
-    this.set("priceToken", Value.fromString(value))
+    this.set("priceToken", Value.fromString(value));
   }
 
   get collateralToken(): string {
-    let value = this.get("collateralToken")
-    return value.toString()
+    let value = this.get("collateralToken");
+    return value.toString();
   }
 
   set collateralToken(value: string) {
-    this.set("collateralToken", Value.fromString(value))
+    this.set("collateralToken", Value.fromString(value));
   }
 
   get tradeFeeBasisPoints(): i32 {
-    let value = this.get("tradeFeeBasisPoints")
-    return value.toI32()
+    let value = this.get("tradeFeeBasisPoints");
+    return value.toI32();
   }
 
   set tradeFeeBasisPoints(value: i32) {
-    this.set("tradeFeeBasisPoints", Value.fromI32(value))
+    this.set("tradeFeeBasisPoints", Value.fromI32(value));
   }
 
   get lpToken(): string {
-    let value = this.get("lpToken")
-    return value.toString()
+    let value = this.get("lpToken");
+    return value.toString();
   }
 
   set lpToken(value: string) {
-    this.set("lpToken", Value.fromString(value))
+    this.set("lpToken", Value.fromString(value));
   }
 
   get poolValueSnapshots(): Array<string | null> {
-    let value = this.get("poolValueSnapshots")
-    return value.toStringArray()
+    let value = this.get("poolValueSnapshots");
+    return value.toStringArray();
   }
 
   set poolValueSnapshots(value: Array<string | null>) {
-    this.set("poolValueSnapshots", Value.fromStringArray(value))
+    this.set("poolValueSnapshots", Value.fromStringArray(value));
   }
 }
 
 export class PoolValueSnapshot extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save PoolValueSnapshot entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save PoolValueSnapshot entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save PoolValueSnapshot entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("PoolValueSnapshot", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("PoolValueSnapshot", id.toString(), this);
   }
 
   static load(id: string): PoolValueSnapshot | null {
-    return store.get("PoolValueSnapshot", id) as PoolValueSnapshot | null
+    return store.get("PoolValueSnapshot", id) as PoolValueSnapshot | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get createdBlock(): BigInt {
-    let value = this.get("createdBlock")
-    return value.toBigInt()
+    let value = this.get("createdBlock");
+    return value.toBigInt();
   }
 
   set createdBlock(value: BigInt) {
-    this.set("createdBlock", Value.fromBigInt(value))
+    this.set("createdBlock", Value.fromBigInt(value));
   }
 
   get createdTimestamp(): BigInt {
-    let value = this.get("createdTimestamp")
-    return value.toBigInt()
+    let value = this.get("createdTimestamp");
+    return value.toBigInt();
   }
 
   set createdTimestamp(value: BigInt) {
-    this.set("createdTimestamp", Value.fromBigInt(value))
+    this.set("createdTimestamp", Value.fromBigInt(value));
   }
 
   get createdTransaction(): Bytes {
-    let value = this.get("createdTransaction")
-    return value.toBytes()
+    let value = this.get("createdTransaction");
+    return value.toBytes();
   }
 
   set createdTransaction(value: Bytes) {
-    this.set("createdTransaction", Value.fromBytes(value))
+    this.set("createdTransaction", Value.fromBytes(value));
   }
 
   get amm(): string {
-    let value = this.get("amm")
-    return value.toString()
+    let value = this.get("amm");
+    return value.toString();
   }
 
   set amm(value: string) {
-    this.set("amm", Value.fromString(value))
+    this.set("amm", Value.fromString(value));
   }
 
   get poolValue(): BigInt {
-    let value = this.get("poolValue")
-    return value.toBigInt()
+    let value = this.get("poolValue");
+    return value.toBigInt();
   }
 
   set poolValue(value: BigInt) {
-    this.set("poolValue", Value.fromBigInt(value))
+    this.set("poolValue", Value.fromBigInt(value));
   }
 
   get lpTokenSupply(): BigInt {
-    let value = this.get("lpTokenSupply")
-    return value.toBigInt()
+    let value = this.get("lpTokenSupply");
+    return value.toBigInt();
   }
 
   set lpTokenSupply(value: BigInt) {
-    this.set("lpTokenSupply", Value.fromBigInt(value))
+    this.set("lpTokenSupply", Value.fromBigInt(value));
   }
 
   get ammTokenEvent(): string {
-    let value = this.get("ammTokenEvent")
-    return value.toString()
+    let value = this.get("ammTokenEvent");
+    return value.toString();
   }
 
   set ammTokenEvent(value: string) {
-    this.set("ammTokenEvent", Value.fromString(value))
+    this.set("ammTokenEvent", Value.fromString(value));
   }
 }
 
 export class SeriesAmm extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save SeriesAmm entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save SeriesAmm entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save SeriesAmm entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("SeriesAmm", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("SeriesAmm", id.toString(), this);
   }
 
   static load(id: string): SeriesAmm | null {
-    return store.get("SeriesAmm", id) as SeriesAmm | null
+    return store.get("SeriesAmm", id) as SeriesAmm | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get series(): string {
-    let value = this.get("series")
-    return value.toString()
+    let value = this.get("series");
+    return value.toString();
   }
 
   set series(value: string) {
-    this.set("series", Value.fromString(value))
+    this.set("series", Value.fromString(value));
   }
 
   get amm(): string {
-    let value = this.get("amm")
-    return value.toString()
+    let value = this.get("amm");
+    return value.toString();
   }
 
   set amm(value: string) {
-    this.set("amm", Value.fromString(value))
+    this.set("amm", Value.fromString(value));
   }
 }
 
 export class Fee extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save Fee entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save Fee entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save Fee entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("Fee", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("Fee", id.toString(), this);
   }
 
   static load(id: string): Fee | null {
-    return store.get("Fee", id) as Fee | null
+    return store.get("Fee", id) as Fee | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get series(): string {
-    let value = this.get("series")
-    return value.toString()
+    let value = this.get("series");
+    return value.toString();
   }
 
   set series(value: string) {
-    this.set("series", Value.fromString(value))
+    this.set("series", Value.fromString(value));
   }
 
   get feeType(): string | null {
-    let value = this.get("feeType")
+    let value = this.get("feeType");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toString()
+      return value.toString();
     }
   }
 
   set feeType(value: string | null) {
     if (value === null) {
-      this.unset("feeType")
+      this.unset("feeType");
     } else {
-      this.set("feeType", Value.fromString(value as string))
+      this.set("feeType", Value.fromString(value as string));
     }
   }
 
   get token(): string {
-    let value = this.get("token")
-    return value.toString()
+    let value = this.get("token");
+    return value.toString();
   }
 
   set token(value: string) {
-    this.set("token", Value.fromString(value))
+    this.set("token", Value.fromString(value));
   }
 
   get value(): BigInt {
-    let value = this.get("value")
-    return value.toBigInt()
+    let value = this.get("value");
+    return value.toBigInt();
   }
 
   set value(value: BigInt) {
-    this.set("value", Value.fromBigInt(value))
+    this.set("value", Value.fromBigInt(value));
   }
 }
 
 export class OptionClose extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save OptionClose entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save OptionClose entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save OptionClose entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("OptionClose", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("OptionClose", id.toString(), this);
   }
 
   static load(id: string): OptionClose | null {
-    return store.get("OptionClose", id) as OptionClose | null
+    return store.get("OptionClose", id) as OptionClose | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get series(): string {
-    let value = this.get("series")
-    return value.toString()
+    let value = this.get("series");
+    return value.toString();
   }
 
   set series(value: string) {
-    this.set("series", Value.fromString(value))
+    this.set("series", Value.fromString(value));
   }
 
   get eventType(): string {
-    let value = this.get("eventType")
-    return value.toString()
+    let value = this.get("eventType");
+    return value.toString();
   }
 
   set eventType(value: string) {
-    this.set("eventType", Value.fromString(value))
+    this.set("eventType", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get optionTokenAmount(): BigInt {
-    let value = this.get("optionTokenAmount")
-    return value.toBigInt()
+    let value = this.get("optionTokenAmount");
+    return value.toBigInt();
   }
 
   set optionTokenAmount(value: BigInt) {
-    this.set("optionTokenAmount", Value.fromBigInt(value))
+    this.set("optionTokenAmount", Value.fromBigInt(value));
   }
 
   get redeemer(): Bytes {
-    let value = this.get("redeemer")
-    return value.toBytes()
+    let value = this.get("redeemer");
+    return value.toBytes();
   }
 
   set redeemer(value: Bytes) {
-    this.set("redeemer", Value.fromBytes(value))
+    this.set("redeemer", Value.fromBytes(value));
   }
 }
 
 export class OptionExercise extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save OptionExercise entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save OptionExercise entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save OptionExercise entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("OptionExercise", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("OptionExercise", id.toString(), this);
   }
 
   static load(id: string): OptionExercise | null {
-    return store.get("OptionExercise", id) as OptionExercise | null
+    return store.get("OptionExercise", id) as OptionExercise | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get series(): string {
-    let value = this.get("series")
-    return value.toString()
+    let value = this.get("series");
+    return value.toString();
   }
 
   set series(value: string) {
-    this.set("series", Value.fromString(value))
+    this.set("series", Value.fromString(value));
   }
 
   get eventType(): string {
-    let value = this.get("eventType")
-    return value.toString()
+    let value = this.get("eventType");
+    return value.toString();
   }
 
   set eventType(value: string) {
-    this.set("eventType", Value.fromString(value))
+    this.set("eventType", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get optionTokenAmount(): BigInt {
-    let value = this.get("optionTokenAmount")
-    return value.toBigInt()
+    let value = this.get("optionTokenAmount");
+    return value.toBigInt();
   }
 
   set optionTokenAmount(value: BigInt) {
-    this.set("optionTokenAmount", Value.fromBigInt(value))
+    this.set("optionTokenAmount", Value.fromBigInt(value));
   }
 
   get collateralAmount(): BigInt {
-    let value = this.get("collateralAmount")
-    return value.toBigInt()
+    let value = this.get("collateralAmount");
+    return value.toBigInt();
   }
 
   set collateralAmount(value: BigInt) {
-    this.set("collateralAmount", Value.fromBigInt(value))
+    this.set("collateralAmount", Value.fromBigInt(value));
   }
 
   get redeemer(): Bytes {
-    let value = this.get("redeemer")
-    return value.toBytes()
+    let value = this.get("redeemer");
+    return value.toBytes();
   }
 
   set redeemer(value: Bytes) {
-    this.set("redeemer", Value.fromBytes(value))
+    this.set("redeemer", Value.fromBytes(value));
   }
 }
 
 export class OptionMint extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save OptionMint entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save OptionMint entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save OptionMint entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("OptionMint", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("OptionMint", id.toString(), this);
   }
 
   static load(id: string): OptionMint | null {
-    return store.get("OptionMint", id) as OptionMint | null
+    return store.get("OptionMint", id) as OptionMint | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get series(): string {
-    let value = this.get("series")
-    return value.toString()
+    let value = this.get("series");
+    return value.toString();
   }
 
   set series(value: string) {
-    this.set("series", Value.fromString(value))
+    this.set("series", Value.fromString(value));
   }
 
   get eventType(): string {
-    let value = this.get("eventType")
-    return value.toString()
+    let value = this.get("eventType");
+    return value.toString();
   }
 
   set eventType(value: string) {
-    this.set("eventType", Value.fromString(value))
+    this.set("eventType", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get optionTokenAmount(): BigInt {
-    let value = this.get("optionTokenAmount")
-    return value.toBigInt()
+    let value = this.get("optionTokenAmount");
+    return value.toBigInt();
   }
 
   set optionTokenAmount(value: BigInt) {
-    this.set("optionTokenAmount", Value.fromBigInt(value))
+    this.set("optionTokenAmount", Value.fromBigInt(value));
   }
 
   get wTokenTotalSupply(): BigInt {
-    let value = this.get("wTokenTotalSupply")
-    return value.toBigInt()
+    let value = this.get("wTokenTotalSupply");
+    return value.toBigInt();
   }
 
   set wTokenTotalSupply(value: BigInt) {
-    this.set("wTokenTotalSupply", Value.fromBigInt(value))
+    this.set("wTokenTotalSupply", Value.fromBigInt(value));
   }
 
   get bTokenTotalSupply(): BigInt {
-    let value = this.get("bTokenTotalSupply")
-    return value.toBigInt()
+    let value = this.get("bTokenTotalSupply");
+    return value.toBigInt();
   }
 
   set bTokenTotalSupply(value: BigInt) {
-    this.set("bTokenTotalSupply", Value.fromBigInt(value))
+    this.set("bTokenTotalSupply", Value.fromBigInt(value));
   }
 
   get minter(): Bytes {
-    let value = this.get("minter")
-    return value.toBytes()
+    let value = this.get("minter");
+    return value.toBytes();
   }
 
   set minter(value: Bytes) {
-    this.set("minter", Value.fromBytes(value))
+    this.set("minter", Value.fromBytes(value));
   }
 }
 
 export class OptionCollateralClaim extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
+    let id = this.get("id");
     assert(
       id !== null,
-      "Cannot save OptionCollateralClaim entity without an ID",
-    )
+      "Cannot save OptionCollateralClaim entity without an ID"
+    );
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save OptionCollateralClaim entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("OptionCollateralClaim", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("OptionCollateralClaim", id.toString(), this);
   }
 
   static load(id: string): OptionCollateralClaim | null {
     return store.get(
       "OptionCollateralClaim",
-      id,
-    ) as OptionCollateralClaim | null
+      id
+    ) as OptionCollateralClaim | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get series(): string {
-    let value = this.get("series")
-    return value.toString()
+    let value = this.get("series");
+    return value.toString();
   }
 
   set series(value: string) {
-    this.set("series", Value.fromString(value))
+    this.set("series", Value.fromString(value));
   }
 
   get eventType(): string {
-    let value = this.get("eventType")
-    return value.toString()
+    let value = this.get("eventType");
+    return value.toString();
   }
 
   set eventType(value: string) {
-    this.set("eventType", Value.fromString(value))
+    this.set("eventType", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get optionTokenAmount(): BigInt {
-    let value = this.get("optionTokenAmount")
-    return value.toBigInt()
+    let value = this.get("optionTokenAmount");
+    return value.toBigInt();
   }
 
   set optionTokenAmount(value: BigInt) {
-    this.set("optionTokenAmount", Value.fromBigInt(value))
+    this.set("optionTokenAmount", Value.fromBigInt(value));
   }
 
   get collateralAmount(): BigInt {
-    let value = this.get("collateralAmount")
-    return value.toBigInt()
+    let value = this.get("collateralAmount");
+    return value.toBigInt();
   }
 
   set collateralAmount(value: BigInt) {
-    this.set("collateralAmount", Value.fromBigInt(value))
+    this.set("collateralAmount", Value.fromBigInt(value));
   }
 
   get redeemer(): Bytes {
-    let value = this.get("redeemer")
-    return value.toBytes()
+    let value = this.get("redeemer");
+    return value.toBytes();
   }
 
   set redeemer(value: Bytes) {
-    this.set("redeemer", Value.fromBytes(value))
+    this.set("redeemer", Value.fromBytes(value));
   }
 }
 
 export class Account extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save Account entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save Account entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save Account entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("Account", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("Account", id.toString(), this);
   }
 
   static load(id: string): Account | null {
-    return store.get("Account", id) as Account | null
+    return store.get("Account", id) as Account | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get address(): Bytes {
-    let value = this.get("address")
-    return value.toBytes()
+    let value = this.get("address");
+    return value.toBytes();
   }
 
   set address(value: Bytes) {
-    this.set("address", Value.fromBytes(value))
+    this.set("address", Value.fromBytes(value));
   }
 
   get erc20Balances(): Array<string> {
-    let value = this.get("erc20Balances")
-    return value.toStringArray()
+    let value = this.get("erc20Balances");
+    return value.toStringArray();
   }
 
   set erc20Balances(value: Array<string>) {
-    this.set("erc20Balances", Value.fromStringArray(value))
+    this.set("erc20Balances", Value.fromStringArray(value));
   }
 
   get erc1155Balances(): Array<string> {
-    let value = this.get("erc1155Balances")
-    return value.toStringArray()
+    let value = this.get("erc1155Balances");
+    return value.toStringArray();
   }
 
   set erc1155Balances(value: Array<string>) {
-    this.set("erc1155Balances", Value.fromStringArray(value))
+    this.set("erc1155Balances", Value.fromStringArray(value));
   }
 
   get ammTokenEvents(): Array<string> {
-    let value = this.get("ammTokenEvents")
-    return value.toStringArray()
+    let value = this.get("ammTokenEvents");
+    return value.toStringArray();
   }
 
   set ammTokenEvents(value: Array<string>) {
-    this.set("ammTokenEvents", Value.fromStringArray(value))
+    this.set("ammTokenEvents", Value.fromStringArray(value));
   }
 }
 
 export class ERC1155Token extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save ERC1155Token entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save ERC1155Token entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC1155Token entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC1155Token", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC1155Token", id.toString(), this);
   }
 
   static load(id: string): ERC1155Token | null {
-    return store.get("ERC1155Token", id) as ERC1155Token | null
+    return store.get("ERC1155Token", id) as ERC1155Token | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get index(): BigInt {
-    let value = this.get("index")
-    return value.toBigInt()
+    let value = this.get("index");
+    return value.toBigInt();
   }
 
   set index(value: BigInt) {
-    this.set("index", Value.fromBigInt(value))
+    this.set("index", Value.fromBigInt(value));
   }
 
   get decimals(): i32 {
-    let value = this.get("decimals")
-    return value.toI32()
+    let value = this.get("decimals");
+    return value.toI32();
   }
 
   set decimals(value: i32) {
-    this.set("decimals", Value.fromI32(value))
+    this.set("decimals", Value.fromI32(value));
   }
 
   get series(): string {
-    let value = this.get("series")
-    return value.toString()
+    let value = this.get("series");
+    return value.toString();
   }
 
   set series(value: string) {
-    this.set("series", Value.fromString(value))
+    this.set("series", Value.fromString(value));
   }
 
   get type(): string | null {
-    let value = this.get("type")
+    let value = this.get("type");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toString()
+      return value.toString();
     }
   }
 
   set type(value: string | null) {
     if (value === null) {
-      this.unset("type")
+      this.unset("type");
     } else {
-      this.set("type", Value.fromString(value as string))
+      this.set("type", Value.fromString(value as string));
     }
   }
 
   get totalSupply(): BigInt {
-    let value = this.get("totalSupply")
-    return value.toBigInt()
+    let value = this.get("totalSupply");
+    return value.toBigInt();
   }
 
   set totalSupply(value: BigInt) {
-    this.set("totalSupply", Value.fromBigInt(value))
+    this.set("totalSupply", Value.fromBigInt(value));
   }
 
   get totalBurned(): BigInt | null {
-    let value = this.get("totalBurned")
+    let value = this.get("totalBurned");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toBigInt()
+      return value.toBigInt();
     }
   }
 
   set totalBurned(value: BigInt | null) {
     if (value === null) {
-      this.unset("totalBurned")
+      this.unset("totalBurned");
     } else {
-      this.set("totalBurned", Value.fromBigInt(value as BigInt))
+      this.set("totalBurned", Value.fromBigInt(value as BigInt));
     }
   }
 
   get totalMinted(): BigInt | null {
-    let value = this.get("totalMinted")
+    let value = this.get("totalMinted");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toBigInt()
+      return value.toBigInt();
     }
   }
 
   set totalMinted(value: BigInt | null) {
     if (value === null) {
-      this.unset("totalMinted")
+      this.unset("totalMinted");
     } else {
-      this.set("totalMinted", Value.fromBigInt(value as BigInt))
+      this.set("totalMinted", Value.fromBigInt(value as BigInt));
     }
   }
 
   get totalTransferred(): BigInt | null {
-    let value = this.get("totalTransferred")
+    let value = this.get("totalTransferred");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toBigInt()
+      return value.toBigInt();
     }
   }
 
   set totalTransferred(value: BigInt | null) {
     if (value === null) {
-      this.unset("totalTransferred")
+      this.unset("totalTransferred");
     } else {
-      this.set("totalTransferred", Value.fromBigInt(value as BigInt))
+      this.set("totalTransferred", Value.fromBigInt(value as BigInt));
     }
   }
 
   get events(): Array<string> {
-    let value = this.get("events")
-    return value.toStringArray()
+    let value = this.get("events");
+    return value.toStringArray();
   }
 
   set events(value: Array<string>) {
-    this.set("events", Value.fromStringArray(value))
+    this.set("events", Value.fromStringArray(value));
   }
 
   get accountBalances(): Array<string> {
-    let value = this.get("accountBalances")
-    return value.toStringArray()
+    let value = this.get("accountBalances");
+    return value.toStringArray();
   }
 
   set accountBalances(value: Array<string>) {
-    this.set("accountBalances", Value.fromStringArray(value))
+    this.set("accountBalances", Value.fromStringArray(value));
   }
 }
 
 export class ERC1155TokenTransfer extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save ERC1155TokenTransfer entity without an ID")
+    let id = this.get("id");
+    assert(
+      id !== null,
+      "Cannot save ERC1155TokenTransfer entity without an ID"
+    );
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC1155TokenTransfer entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC1155TokenTransfer", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC1155TokenTransfer", id.toString(), this);
   }
 
   static load(id: string): ERC1155TokenTransfer | null {
-    return store.get("ERC1155TokenTransfer", id) as ERC1155TokenTransfer | null
+    return store.get("ERC1155TokenTransfer", id) as ERC1155TokenTransfer | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get tokens(): Array<string> {
-    let value = this.get("tokens")
-    return value.toStringArray()
+    let value = this.get("tokens");
+    return value.toStringArray();
   }
 
   set tokens(value: Array<string>) {
-    this.set("tokens", Value.fromStringArray(value))
+    this.set("tokens", Value.fromStringArray(value));
   }
 
   get amounts(): Array<BigInt> {
-    let value = this.get("amounts")
-    return value.toBigIntArray()
+    let value = this.get("amounts");
+    return value.toBigIntArray();
   }
 
   set amounts(value: Array<BigInt>) {
-    this.set("amounts", Value.fromBigIntArray(value))
+    this.set("amounts", Value.fromBigIntArray(value));
   }
 
   get operator(): Bytes {
-    let value = this.get("operator")
-    return value.toBytes()
+    let value = this.get("operator");
+    return value.toBytes();
   }
 
   set operator(value: Bytes) {
-    this.set("operator", Value.fromBytes(value))
+    this.set("operator", Value.fromBytes(value));
   }
 
   get sender(): Bytes {
-    let value = this.get("sender")
-    return value.toBytes()
+    let value = this.get("sender");
+    return value.toBytes();
   }
 
   set sender(value: Bytes) {
-    this.set("sender", Value.fromBytes(value))
+    this.set("sender", Value.fromBytes(value));
   }
 
   get eventType(): string {
-    let value = this.get("eventType")
-    return value.toString()
+    let value = this.get("eventType");
+    return value.toString();
   }
 
   set eventType(value: string) {
-    this.set("eventType", Value.fromString(value))
+    this.set("eventType", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get from(): Bytes {
-    let value = this.get("from")
-    return value.toBytes()
+    let value = this.get("from");
+    return value.toBytes();
   }
 
   set from(value: Bytes) {
-    this.set("from", Value.fromBytes(value))
+    this.set("from", Value.fromBytes(value));
   }
 
   get to(): Bytes {
-    let value = this.get("to")
-    return value.toBytes()
+    let value = this.get("to");
+    return value.toBytes();
   }
 
   set to(value: Bytes) {
-    this.set("to", Value.fromBytes(value))
+    this.set("to", Value.fromBytes(value));
   }
 }
 
 export class ERC1155TokenMint extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save ERC1155TokenMint entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save ERC1155TokenMint entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC1155TokenMint entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC1155TokenMint", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC1155TokenMint", id.toString(), this);
   }
 
   static load(id: string): ERC1155TokenMint | null {
-    return store.get("ERC1155TokenMint", id) as ERC1155TokenMint | null
+    return store.get("ERC1155TokenMint", id) as ERC1155TokenMint | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get tokens(): Array<string> {
-    let value = this.get("tokens")
-    return value.toStringArray()
+    let value = this.get("tokens");
+    return value.toStringArray();
   }
 
   set tokens(value: Array<string>) {
-    this.set("tokens", Value.fromStringArray(value))
+    this.set("tokens", Value.fromStringArray(value));
   }
 
   get amounts(): Array<BigInt> {
-    let value = this.get("amounts")
-    return value.toBigIntArray()
+    let value = this.get("amounts");
+    return value.toBigIntArray();
   }
 
   set amounts(value: Array<BigInt>) {
-    this.set("amounts", Value.fromBigIntArray(value))
+    this.set("amounts", Value.fromBigIntArray(value));
   }
 
   get operator(): Bytes {
-    let value = this.get("operator")
-    return value.toBytes()
+    let value = this.get("operator");
+    return value.toBytes();
   }
 
   set operator(value: Bytes) {
-    this.set("operator", Value.fromBytes(value))
+    this.set("operator", Value.fromBytes(value));
   }
 
   get sender(): Bytes {
-    let value = this.get("sender")
-    return value.toBytes()
+    let value = this.get("sender");
+    return value.toBytes();
   }
 
   set sender(value: Bytes) {
-    this.set("sender", Value.fromBytes(value))
+    this.set("sender", Value.fromBytes(value));
   }
 
   get eventType(): string {
-    let value = this.get("eventType")
-    return value.toString()
+    let value = this.get("eventType");
+    return value.toString();
   }
 
   set eventType(value: string) {
-    this.set("eventType", Value.fromString(value))
+    this.set("eventType", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get minter(): Bytes {
-    let value = this.get("minter")
-    return value.toBytes()
+    let value = this.get("minter");
+    return value.toBytes();
   }
 
   set minter(value: Bytes) {
-    this.set("minter", Value.fromBytes(value))
+    this.set("minter", Value.fromBytes(value));
   }
 
   get destination(): Bytes {
-    let value = this.get("destination")
-    return value.toBytes()
+    let value = this.get("destination");
+    return value.toBytes();
   }
 
   set destination(value: Bytes) {
-    this.set("destination", Value.fromBytes(value))
+    this.set("destination", Value.fromBytes(value));
   }
 }
 
 export class ERC1155TokenBurn extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save ERC1155TokenBurn entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save ERC1155TokenBurn entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC1155TokenBurn entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC1155TokenBurn", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC1155TokenBurn", id.toString(), this);
   }
 
   static load(id: string): ERC1155TokenBurn | null {
-    return store.get("ERC1155TokenBurn", id) as ERC1155TokenBurn | null
+    return store.get("ERC1155TokenBurn", id) as ERC1155TokenBurn | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get tokens(): Array<string> {
-    let value = this.get("tokens")
-    return value.toStringArray()
+    let value = this.get("tokens");
+    return value.toStringArray();
   }
 
   set tokens(value: Array<string>) {
-    this.set("tokens", Value.fromStringArray(value))
+    this.set("tokens", Value.fromStringArray(value));
   }
 
   get amounts(): Array<BigInt> {
-    let value = this.get("amounts")
-    return value.toBigIntArray()
+    let value = this.get("amounts");
+    return value.toBigIntArray();
   }
 
   set amounts(value: Array<BigInt>) {
-    this.set("amounts", Value.fromBigIntArray(value))
+    this.set("amounts", Value.fromBigIntArray(value));
   }
 
   get operator(): Bytes {
-    let value = this.get("operator")
-    return value.toBytes()
+    let value = this.get("operator");
+    return value.toBytes();
   }
 
   set operator(value: Bytes) {
-    this.set("operator", Value.fromBytes(value))
+    this.set("operator", Value.fromBytes(value));
   }
 
   get sender(): Bytes {
-    let value = this.get("sender")
-    return value.toBytes()
+    let value = this.get("sender");
+    return value.toBytes();
   }
 
   set sender(value: Bytes) {
-    this.set("sender", Value.fromBytes(value))
+    this.set("sender", Value.fromBytes(value));
   }
 
   get eventType(): string {
-    let value = this.get("eventType")
-    return value.toString()
+    let value = this.get("eventType");
+    return value.toString();
   }
 
   set eventType(value: string) {
-    this.set("eventType", Value.fromString(value))
+    this.set("eventType", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get burner(): Bytes {
-    let value = this.get("burner")
-    return value.toBytes()
+    let value = this.get("burner");
+    return value.toBytes();
   }
 
   set burner(value: Bytes) {
-    this.set("burner", Value.fromBytes(value))
+    this.set("burner", Value.fromBytes(value));
   }
 }
 
 export class ERC1155TokenApprovalForAll extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
+    let id = this.get("id");
     assert(
       id !== null,
-      "Cannot save ERC1155TokenApprovalForAll entity without an ID",
-    )
+      "Cannot save ERC1155TokenApprovalForAll entity without an ID"
+    );
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC1155TokenApprovalForAll entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC1155TokenApprovalForAll", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC1155TokenApprovalForAll", id.toString(), this);
   }
 
   static load(id: string): ERC1155TokenApprovalForAll | null {
     return store.get(
       "ERC1155TokenApprovalForAll",
-      id,
-    ) as ERC1155TokenApprovalForAll | null
+      id
+    ) as ERC1155TokenApprovalForAll | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get erc1155Controller(): Bytes {
-    let value = this.get("erc1155Controller")
-    return value.toBytes()
+    let value = this.get("erc1155Controller");
+    return value.toBytes();
   }
 
   set erc1155Controller(value: Bytes) {
-    this.set("erc1155Controller", Value.fromBytes(value))
+    this.set("erc1155Controller", Value.fromBytes(value));
   }
 
   get owner(): Bytes {
-    let value = this.get("owner")
-    return value.toBytes()
+    let value = this.get("owner");
+    return value.toBytes();
   }
 
   set owner(value: Bytes) {
-    this.set("owner", Value.fromBytes(value))
+    this.set("owner", Value.fromBytes(value));
   }
 
   get operator(): Bytes {
-    let value = this.get("operator")
-    return value.toBytes()
+    let value = this.get("operator");
+    return value.toBytes();
   }
 
   set operator(value: Bytes) {
-    this.set("operator", Value.fromBytes(value))
+    this.set("operator", Value.fromBytes(value));
   }
 
   get sender(): Bytes {
-    let value = this.get("sender")
-    return value.toBytes()
+    let value = this.get("sender");
+    return value.toBytes();
   }
 
   set sender(value: Bytes) {
-    this.set("sender", Value.fromBytes(value))
+    this.set("sender", Value.fromBytes(value));
   }
 
   get approved(): boolean {
-    let value = this.get("approved")
-    return value.toBoolean()
+    let value = this.get("approved");
+    return value.toBoolean();
   }
 
   set approved(value: boolean) {
-    this.set("approved", Value.fromBoolean(value))
+    this.set("approved", Value.fromBoolean(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 }
 
 export class ERC1155AccountBalance extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
+    let id = this.get("id");
     assert(
       id !== null,
-      "Cannot save ERC1155AccountBalance entity without an ID",
-    )
+      "Cannot save ERC1155AccountBalance entity without an ID"
+    );
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC1155AccountBalance entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC1155AccountBalance", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC1155AccountBalance", id.toString(), this);
   }
 
   static load(id: string): ERC1155AccountBalance | null {
     return store.get(
       "ERC1155AccountBalance",
-      id,
-    ) as ERC1155AccountBalance | null
+      id
+    ) as ERC1155AccountBalance | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get account(): string {
-    let value = this.get("account")
-    return value.toString()
+    let value = this.get("account");
+    return value.toString();
   }
 
   set account(value: string) {
-    this.set("account", Value.fromString(value))
+    this.set("account", Value.fromString(value));
   }
 
   get token(): string {
-    let value = this.get("token")
-    return value.toString()
+    let value = this.get("token");
+    return value.toString();
   }
 
   set token(value: string) {
-    this.set("token", Value.fromString(value))
+    this.set("token", Value.fromString(value));
   }
 
   get amount(): BigInt {
-    let value = this.get("amount")
-    return value.toBigInt()
+    let value = this.get("amount");
+    return value.toBigInt();
   }
 
   set amount(value: BigInt) {
-    this.set("amount", Value.fromBigInt(value))
+    this.set("amount", Value.fromBigInt(value));
   }
 
   get block(): BigInt | null {
-    let value = this.get("block")
+    let value = this.get("block");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toBigInt()
+      return value.toBigInt();
     }
   }
 
   set block(value: BigInt | null) {
     if (value === null) {
-      this.unset("block")
+      this.unset("block");
     } else {
-      this.set("block", Value.fromBigInt(value as BigInt))
+      this.set("block", Value.fromBigInt(value as BigInt));
     }
   }
 
   get modified(): BigInt | null {
-    let value = this.get("modified")
+    let value = this.get("modified");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toBigInt()
+      return value.toBigInt();
     }
   }
 
   set modified(value: BigInt | null) {
     if (value === null) {
-      this.unset("modified")
+      this.unset("modified");
     } else {
-      this.set("modified", Value.fromBigInt(value as BigInt))
+      this.set("modified", Value.fromBigInt(value as BigInt));
     }
   }
 
   get transaction(): Bytes | null {
-    let value = this.get("transaction")
+    let value = this.get("transaction");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toBytes()
+      return value.toBytes();
     }
   }
 
   set transaction(value: Bytes | null) {
     if (value === null) {
-      this.unset("transaction")
+      this.unset("transaction");
     } else {
-      this.set("transaction", Value.fromBytes(value as Bytes))
+      this.set("transaction", Value.fromBytes(value as Bytes));
     }
   }
 }
 
 export class ERC1155AccountBalanceSnapshot extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
+    let id = this.get("id");
     assert(
       id !== null,
-      "Cannot save ERC1155AccountBalanceSnapshot entity without an ID",
-    )
+      "Cannot save ERC1155AccountBalanceSnapshot entity without an ID"
+    );
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC1155AccountBalanceSnapshot entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC1155AccountBalanceSnapshot", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC1155AccountBalanceSnapshot", id.toString(), this);
   }
 
   static load(id: string): ERC1155AccountBalanceSnapshot | null {
     return store.get(
       "ERC1155AccountBalanceSnapshot",
-      id,
-    ) as ERC1155AccountBalanceSnapshot | null
+      id
+    ) as ERC1155AccountBalanceSnapshot | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get account(): string {
-    let value = this.get("account")
-    return value.toString()
+    let value = this.get("account");
+    return value.toString();
   }
 
   set account(value: string) {
-    this.set("account", Value.fromString(value))
+    this.set("account", Value.fromString(value));
   }
 
   get token(): string {
-    let value = this.get("token")
-    return value.toString()
+    let value = this.get("token");
+    return value.toString();
   }
 
   set token(value: string) {
-    this.set("token", Value.fromString(value))
+    this.set("token", Value.fromString(value));
   }
 
   get amount(): BigInt {
-    let value = this.get("amount")
-    return value.toBigInt()
+    let value = this.get("amount");
+    return value.toBigInt();
   }
 
   set amount(value: BigInt) {
-    this.set("amount", Value.fromBigInt(value))
+    this.set("amount", Value.fromBigInt(value));
   }
 
   get event(): string | null {
-    let value = this.get("event")
+    let value = this.get("event");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toString()
+      return value.toString();
     }
   }
 
   set event(value: string | null) {
     if (value === null) {
-      this.unset("event")
+      this.unset("event");
     } else {
-      this.set("event", Value.fromString(value as string))
+      this.set("event", Value.fromString(value as string));
     }
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get transaction(): Bytes {
-    let value = this.get("transaction")
-    return value.toBytes()
+    let value = this.get("transaction");
+    return value.toBytes();
   }
 
   set transaction(value: Bytes) {
-    this.set("transaction", Value.fromBytes(value))
+    this.set("transaction", Value.fromBytes(value));
   }
 }
 
 export class ERC20Token extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save ERC20Token entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save ERC20Token entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC20Token entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC20Token", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC20Token", id.toString(), this);
   }
 
   static load(id: string): ERC20Token | null {
-    return store.get("ERC20Token", id) as ERC20Token | null
+    return store.get("ERC20Token", id) as ERC20Token | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get type(): string | null {
-    let value = this.get("type")
+    let value = this.get("type");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toString()
+      return value.toString();
     }
   }
 
   set type(value: string | null) {
     if (value === null) {
-      this.unset("type")
+      this.unset("type");
     } else {
-      this.set("type", Value.fromString(value as string))
+      this.set("type", Value.fromString(value as string));
     }
   }
 
   get decimals(): i32 {
-    let value = this.get("decimals")
-    return value.toI32()
+    let value = this.get("decimals");
+    return value.toI32();
   }
 
   set decimals(value: i32) {
-    this.set("decimals", Value.fromI32(value))
+    this.set("decimals", Value.fromI32(value));
   }
 
   get name(): string {
-    let value = this.get("name")
-    return value.toString()
+    let value = this.get("name");
+    return value.toString();
   }
 
   set name(value: string) {
-    this.set("name", Value.fromString(value))
+    this.set("name", Value.fromString(value));
   }
 
   get symbol(): string {
-    let value = this.get("symbol")
-    return value.toString()
+    let value = this.get("symbol");
+    return value.toString();
   }
 
   set symbol(value: string) {
-    this.set("symbol", Value.fromString(value))
+    this.set("symbol", Value.fromString(value));
   }
 
   get totalSupply(): BigInt {
-    let value = this.get("totalSupply")
-    return value.toBigInt()
+    let value = this.get("totalSupply");
+    return value.toBigInt();
   }
 
   set totalSupply(value: BigInt) {
-    this.set("totalSupply", Value.fromBigInt(value))
+    this.set("totalSupply", Value.fromBigInt(value));
   }
 
   get totalBurned(): BigInt | null {
-    let value = this.get("totalBurned")
+    let value = this.get("totalBurned");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toBigInt()
+      return value.toBigInt();
     }
   }
 
   set totalBurned(value: BigInt | null) {
     if (value === null) {
-      this.unset("totalBurned")
+      this.unset("totalBurned");
     } else {
-      this.set("totalBurned", Value.fromBigInt(value as BigInt))
+      this.set("totalBurned", Value.fromBigInt(value as BigInt));
     }
   }
 
   get totalMinted(): BigInt | null {
-    let value = this.get("totalMinted")
+    let value = this.get("totalMinted");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toBigInt()
+      return value.toBigInt();
     }
   }
 
   set totalMinted(value: BigInt | null) {
     if (value === null) {
-      this.unset("totalMinted")
+      this.unset("totalMinted");
     } else {
-      this.set("totalMinted", Value.fromBigInt(value as BigInt))
+      this.set("totalMinted", Value.fromBigInt(value as BigInt));
     }
   }
 
   get totalTransferred(): BigInt | null {
-    let value = this.get("totalTransferred")
+    let value = this.get("totalTransferred");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toBigInt()
+      return value.toBigInt();
     }
   }
 
   set totalTransferred(value: BigInt | null) {
     if (value === null) {
-      this.unset("totalTransferred")
+      this.unset("totalTransferred");
     } else {
-      this.set("totalTransferred", Value.fromBigInt(value as BigInt))
+      this.set("totalTransferred", Value.fromBigInt(value as BigInt));
     }
   }
 
   get events(): Array<string> {
-    let value = this.get("events")
-    return value.toStringArray()
+    let value = this.get("events");
+    return value.toStringArray();
   }
 
   set events(value: Array<string>) {
-    this.set("events", Value.fromStringArray(value))
+    this.set("events", Value.fromStringArray(value));
   }
 
   get accountBalances(): Array<string> {
-    let value = this.get("accountBalances")
-    return value.toStringArray()
+    let value = this.get("accountBalances");
+    return value.toStringArray();
   }
 
   set accountBalances(value: Array<string>) {
-    this.set("accountBalances", Value.fromStringArray(value))
+    this.set("accountBalances", Value.fromStringArray(value));
   }
 }
 
 export class ERC20TokenTransfer extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save ERC20TokenTransfer entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save ERC20TokenTransfer entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC20TokenTransfer entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC20TokenTransfer", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC20TokenTransfer", id.toString(), this);
   }
 
   static load(id: string): ERC20TokenTransfer | null {
-    return store.get("ERC20TokenTransfer", id) as ERC20TokenTransfer | null
+    return store.get("ERC20TokenTransfer", id) as ERC20TokenTransfer | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get token(): string {
-    let value = this.get("token")
-    return value.toString()
+    let value = this.get("token");
+    return value.toString();
   }
 
   set token(value: string) {
-    this.set("token", Value.fromString(value))
+    this.set("token", Value.fromString(value));
   }
 
   get amount(): BigInt {
-    let value = this.get("amount")
-    return value.toBigInt()
+    let value = this.get("amount");
+    return value.toBigInt();
   }
 
   set amount(value: BigInt) {
-    this.set("amount", Value.fromBigInt(value))
+    this.set("amount", Value.fromBigInt(value));
   }
 
   get sender(): Bytes {
-    let value = this.get("sender")
-    return value.toBytes()
+    let value = this.get("sender");
+    return value.toBytes();
   }
 
   set sender(value: Bytes) {
-    this.set("sender", Value.fromBytes(value))
+    this.set("sender", Value.fromBytes(value));
   }
 
   get eventType(): string {
-    let value = this.get("eventType")
-    return value.toString()
+    let value = this.get("eventType");
+    return value.toString();
   }
 
   set eventType(value: string) {
-    this.set("eventType", Value.fromString(value))
+    this.set("eventType", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get from(): Bytes {
-    let value = this.get("from")
-    return value.toBytes()
+    let value = this.get("from");
+    return value.toBytes();
   }
 
   set from(value: Bytes) {
-    this.set("from", Value.fromBytes(value))
+    this.set("from", Value.fromBytes(value));
   }
 
   get to(): Bytes {
-    let value = this.get("to")
-    return value.toBytes()
+    let value = this.get("to");
+    return value.toBytes();
   }
 
   set to(value: Bytes) {
-    this.set("to", Value.fromBytes(value))
+    this.set("to", Value.fromBytes(value));
   }
 }
 
 export class ERC20TokenApproval extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save ERC20TokenApproval entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save ERC20TokenApproval entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC20TokenApproval entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC20TokenApproval", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC20TokenApproval", id.toString(), this);
   }
 
   static load(id: string): ERC20TokenApproval | null {
-    return store.get("ERC20TokenApproval", id) as ERC20TokenApproval | null
+    return store.get("ERC20TokenApproval", id) as ERC20TokenApproval | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get token(): string {
-    let value = this.get("token")
-    return value.toString()
+    let value = this.get("token");
+    return value.toString();
   }
 
   set token(value: string) {
-    this.set("token", Value.fromString(value))
+    this.set("token", Value.fromString(value));
   }
 
   get amount(): BigInt {
-    let value = this.get("amount")
-    return value.toBigInt()
+    let value = this.get("amount");
+    return value.toBigInt();
   }
 
   set amount(value: BigInt) {
-    this.set("amount", Value.fromBigInt(value))
+    this.set("amount", Value.fromBigInt(value));
   }
 
   get sender(): Bytes {
-    let value = this.get("sender")
-    return value.toBytes()
+    let value = this.get("sender");
+    return value.toBytes();
   }
 
   set sender(value: Bytes) {
-    this.set("sender", Value.fromBytes(value))
+    this.set("sender", Value.fromBytes(value));
   }
 
   get eventType(): string {
-    let value = this.get("eventType")
-    return value.toString()
+    let value = this.get("eventType");
+    return value.toString();
   }
 
   set eventType(value: string) {
-    this.set("eventType", Value.fromString(value))
+    this.set("eventType", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get owner(): Bytes {
-    let value = this.get("owner")
-    return value.toBytes()
+    let value = this.get("owner");
+    return value.toBytes();
   }
 
   set owner(value: Bytes) {
-    this.set("owner", Value.fromBytes(value))
+    this.set("owner", Value.fromBytes(value));
   }
 
   get spender(): Bytes {
-    let value = this.get("spender")
-    return value.toBytes()
+    let value = this.get("spender");
+    return value.toBytes();
   }
 
   set spender(value: Bytes) {
-    this.set("spender", Value.fromBytes(value))
+    this.set("spender", Value.fromBytes(value));
   }
 }
 
 export class ERC20TokenMint extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save ERC20TokenMint entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save ERC20TokenMint entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC20TokenMint entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC20TokenMint", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC20TokenMint", id.toString(), this);
   }
 
   static load(id: string): ERC20TokenMint | null {
-    return store.get("ERC20TokenMint", id) as ERC20TokenMint | null
+    return store.get("ERC20TokenMint", id) as ERC20TokenMint | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get token(): string {
-    let value = this.get("token")
-    return value.toString()
+    let value = this.get("token");
+    return value.toString();
   }
 
   set token(value: string) {
-    this.set("token", Value.fromString(value))
+    this.set("token", Value.fromString(value));
   }
 
   get amount(): BigInt {
-    let value = this.get("amount")
-    return value.toBigInt()
+    let value = this.get("amount");
+    return value.toBigInt();
   }
 
   set amount(value: BigInt) {
-    this.set("amount", Value.fromBigInt(value))
+    this.set("amount", Value.fromBigInt(value));
   }
 
   get sender(): Bytes {
-    let value = this.get("sender")
-    return value.toBytes()
+    let value = this.get("sender");
+    return value.toBytes();
   }
 
   set sender(value: Bytes) {
-    this.set("sender", Value.fromBytes(value))
+    this.set("sender", Value.fromBytes(value));
   }
 
   get eventType(): string {
-    let value = this.get("eventType")
-    return value.toString()
+    let value = this.get("eventType");
+    return value.toString();
   }
 
   set eventType(value: string) {
-    this.set("eventType", Value.fromString(value))
+    this.set("eventType", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get minter(): Bytes {
-    let value = this.get("minter")
-    return value.toBytes()
+    let value = this.get("minter");
+    return value.toBytes();
   }
 
   set minter(value: Bytes) {
-    this.set("minter", Value.fromBytes(value))
+    this.set("minter", Value.fromBytes(value));
   }
 
   get destination(): Bytes {
-    let value = this.get("destination")
-    return value.toBytes()
+    let value = this.get("destination");
+    return value.toBytes();
   }
 
   set destination(value: Bytes) {
-    this.set("destination", Value.fromBytes(value))
+    this.set("destination", Value.fromBytes(value));
   }
 }
 
 export class ERC20TokenBurn extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save ERC20TokenBurn entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save ERC20TokenBurn entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC20TokenBurn entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC20TokenBurn", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC20TokenBurn", id.toString(), this);
   }
 
   static load(id: string): ERC20TokenBurn | null {
-    return store.get("ERC20TokenBurn", id) as ERC20TokenBurn | null
+    return store.get("ERC20TokenBurn", id) as ERC20TokenBurn | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get token(): string {
-    let value = this.get("token")
-    return value.toString()
+    let value = this.get("token");
+    return value.toString();
   }
 
   set token(value: string) {
-    this.set("token", Value.fromString(value))
+    this.set("token", Value.fromString(value));
   }
 
   get amount(): BigInt {
-    let value = this.get("amount")
-    return value.toBigInt()
+    let value = this.get("amount");
+    return value.toBigInt();
   }
 
   set amount(value: BigInt) {
-    this.set("amount", Value.fromBigInt(value))
+    this.set("amount", Value.fromBigInt(value));
   }
 
   get sender(): Bytes {
-    let value = this.get("sender")
-    return value.toBytes()
+    let value = this.get("sender");
+    return value.toBytes();
   }
 
   set sender(value: Bytes) {
-    this.set("sender", Value.fromBytes(value))
+    this.set("sender", Value.fromBytes(value));
   }
 
   get eventType(): string {
-    let value = this.get("eventType")
-    return value.toString()
+    let value = this.get("eventType");
+    return value.toString();
   }
 
   set eventType(value: string) {
-    this.set("eventType", Value.fromString(value))
+    this.set("eventType", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get burner(): Bytes {
-    let value = this.get("burner")
-    return value.toBytes()
+    let value = this.get("burner");
+    return value.toBytes();
   }
 
   set burner(value: Bytes) {
-    this.set("burner", Value.fromBytes(value))
+    this.set("burner", Value.fromBytes(value));
   }
 }
 
 export class LpTokenMinted extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save LpTokenMinted entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save LpTokenMinted entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save LpTokenMinted entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("LpTokenMinted", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("LpTokenMinted", id.toString(), this);
   }
 
   static load(id: string): LpTokenMinted | null {
-    return store.get("LpTokenMinted", id) as LpTokenMinted | null
+    return store.get("LpTokenMinted", id) as LpTokenMinted | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get account(): string {
-    let value = this.get("account")
-    return value.toString()
+    let value = this.get("account");
+    return value.toString();
   }
 
   set account(value: string) {
-    this.set("account", Value.fromString(value))
+    this.set("account", Value.fromString(value));
   }
 
   get collateralAmount(): BigInt {
-    let value = this.get("collateralAmount")
-    return value.toBigInt()
+    let value = this.get("collateralAmount");
+    return value.toBigInt();
   }
 
   set collateralAmount(value: BigInt) {
-    this.set("collateralAmount", Value.fromBigInt(value))
+    this.set("collateralAmount", Value.fromBigInt(value));
   }
 
   get tokenAmount(): BigInt {
-    let value = this.get("tokenAmount")
-    return value.toBigInt()
+    let value = this.get("tokenAmount");
+    return value.toBigInt();
   }
 
   set tokenAmount(value: BigInt) {
-    this.set("tokenAmount", Value.fromBigInt(value))
+    this.set("tokenAmount", Value.fromBigInt(value));
   }
 
   get eventType(): Array<string | null> {
-    let value = this.get("eventType")
-    return value.toStringArray()
+    let value = this.get("eventType");
+    return value.toStringArray();
   }
 
   set eventType(value: Array<string | null>) {
-    this.set("eventType", Value.fromStringArray(value))
+    this.set("eventType", Value.fromStringArray(value));
   }
 
   get amm(): string {
-    let value = this.get("amm")
-    return value.toString()
+    let value = this.get("amm");
+    return value.toString();
   }
 
   set amm(value: string) {
-    this.set("amm", Value.fromString(value))
+    this.set("amm", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get poolValueSnapshot(): string {
-    let value = this.get("poolValueSnapshot")
-    return value.toString()
+    let value = this.get("poolValueSnapshot");
+    return value.toString();
   }
 
   set poolValueSnapshot(value: string) {
-    this.set("poolValueSnapshot", Value.fromString(value))
+    this.set("poolValueSnapshot", Value.fromString(value));
   }
 }
 
 export class LpTokenBurned extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save LpTokenBurned entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save LpTokenBurned entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save LpTokenBurned entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("LpTokenBurned", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("LpTokenBurned", id.toString(), this);
   }
 
   static load(id: string): LpTokenBurned | null {
-    return store.get("LpTokenBurned", id) as LpTokenBurned | null
+    return store.get("LpTokenBurned", id) as LpTokenBurned | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get account(): string {
-    let value = this.get("account")
-    return value.toString()
+    let value = this.get("account");
+    return value.toString();
   }
 
   set account(value: string) {
-    this.set("account", Value.fromString(value))
+    this.set("account", Value.fromString(value));
   }
 
   get collateralAmount(): BigInt {
-    let value = this.get("collateralAmount")
-    return value.toBigInt()
+    let value = this.get("collateralAmount");
+    return value.toBigInt();
   }
 
   set collateralAmount(value: BigInt) {
-    this.set("collateralAmount", Value.fromBigInt(value))
+    this.set("collateralAmount", Value.fromBigInt(value));
   }
 
   get tokenAmount(): BigInt {
-    let value = this.get("tokenAmount")
-    return value.toBigInt()
+    let value = this.get("tokenAmount");
+    return value.toBigInt();
   }
 
   set tokenAmount(value: BigInt) {
-    this.set("tokenAmount", Value.fromBigInt(value))
+    this.set("tokenAmount", Value.fromBigInt(value));
   }
 
   get eventType(): Array<string | null> {
-    let value = this.get("eventType")
-    return value.toStringArray()
+    let value = this.get("eventType");
+    return value.toStringArray();
   }
 
   set eventType(value: Array<string | null>) {
-    this.set("eventType", Value.fromStringArray(value))
+    this.set("eventType", Value.fromStringArray(value));
   }
 
   get amm(): string {
-    let value = this.get("amm")
-    return value.toString()
+    let value = this.get("amm");
+    return value.toString();
   }
 
   set amm(value: string) {
-    this.set("amm", Value.fromString(value))
+    this.set("amm", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get poolValueSnapshot(): string {
-    let value = this.get("poolValueSnapshot")
-    return value.toString()
+    let value = this.get("poolValueSnapshot");
+    return value.toString();
   }
 
   set poolValueSnapshot(value: string) {
-    this.set("poolValueSnapshot", Value.fromString(value))
+    this.set("poolValueSnapshot", Value.fromString(value));
   }
 }
 
 export class BTokenBought extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save BTokenBought entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save BTokenBought entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save BTokenBought entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("BTokenBought", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("BTokenBought", id.toString(), this);
   }
 
   static load(id: string): BTokenBought | null {
-    return store.get("BTokenBought", id) as BTokenBought | null
+    return store.get("BTokenBought", id) as BTokenBought | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get account(): string {
-    let value = this.get("account")
-    return value.toString()
+    let value = this.get("account");
+    return value.toString();
   }
 
   set account(value: string) {
-    this.set("account", Value.fromString(value))
+    this.set("account", Value.fromString(value));
   }
 
   get collateralAmount(): BigInt {
-    let value = this.get("collateralAmount")
-    return value.toBigInt()
+    let value = this.get("collateralAmount");
+    return value.toBigInt();
   }
 
   set collateralAmount(value: BigInt) {
-    this.set("collateralAmount", Value.fromBigInt(value))
+    this.set("collateralAmount", Value.fromBigInt(value));
   }
 
   get tokenAmount(): BigInt {
-    let value = this.get("tokenAmount")
-    return value.toBigInt()
+    let value = this.get("tokenAmount");
+    return value.toBigInt();
   }
 
   set tokenAmount(value: BigInt) {
-    this.set("tokenAmount", Value.fromBigInt(value))
+    this.set("tokenAmount", Value.fromBigInt(value));
   }
 
   get eventType(): Array<string | null> {
-    let value = this.get("eventType")
-    return value.toStringArray()
+    let value = this.get("eventType");
+    return value.toStringArray();
   }
 
   set eventType(value: Array<string | null>) {
-    this.set("eventType", Value.fromStringArray(value))
+    this.set("eventType", Value.fromStringArray(value));
   }
 
   get amm(): string {
-    let value = this.get("amm")
-    return value.toString()
+    let value = this.get("amm");
+    return value.toString();
   }
 
   set amm(value: string) {
-    this.set("amm", Value.fromString(value))
+    this.set("amm", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get poolValueSnapshot(): string {
-    let value = this.get("poolValueSnapshot")
-    return value.toString()
+    let value = this.get("poolValueSnapshot");
+    return value.toString();
   }
 
   set poolValueSnapshot(value: string) {
-    this.set("poolValueSnapshot", Value.fromString(value))
+    this.set("poolValueSnapshot", Value.fromString(value));
+  }
+
+  get seriesId(): i32 {
+    let value = this.get("seriesId");
+    return value.toI32();
+  }
+
+  set seriesId(value: i32) {
+    this.set("seriesId", Value.fromI32(value));
   }
 }
 
 export class BTokenSold extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save BTokenSold entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save BTokenSold entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save BTokenSold entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("BTokenSold", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("BTokenSold", id.toString(), this);
   }
 
   static load(id: string): BTokenSold | null {
-    return store.get("BTokenSold", id) as BTokenSold | null
+    return store.get("BTokenSold", id) as BTokenSold | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get account(): string {
-    let value = this.get("account")
-    return value.toString()
+    let value = this.get("account");
+    return value.toString();
   }
 
   set account(value: string) {
-    this.set("account", Value.fromString(value))
+    this.set("account", Value.fromString(value));
   }
 
   get collateralAmount(): BigInt {
-    let value = this.get("collateralAmount")
-    return value.toBigInt()
+    let value = this.get("collateralAmount");
+    return value.toBigInt();
   }
 
   set collateralAmount(value: BigInt) {
-    this.set("collateralAmount", Value.fromBigInt(value))
+    this.set("collateralAmount", Value.fromBigInt(value));
   }
 
   get tokenAmount(): BigInt {
-    let value = this.get("tokenAmount")
-    return value.toBigInt()
+    let value = this.get("tokenAmount");
+    return value.toBigInt();
   }
 
   set tokenAmount(value: BigInt) {
-    this.set("tokenAmount", Value.fromBigInt(value))
+    this.set("tokenAmount", Value.fromBigInt(value));
   }
 
   get eventType(): Array<string | null> {
-    let value = this.get("eventType")
-    return value.toStringArray()
+    let value = this.get("eventType");
+    return value.toStringArray();
   }
 
   set eventType(value: Array<string | null>) {
-    this.set("eventType", Value.fromStringArray(value))
+    this.set("eventType", Value.fromStringArray(value));
   }
 
   get amm(): string {
-    let value = this.get("amm")
-    return value.toString()
+    let value = this.get("amm");
+    return value.toString();
   }
 
   set amm(value: string) {
-    this.set("amm", Value.fromString(value))
+    this.set("amm", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get poolValueSnapshot(): string {
-    let value = this.get("poolValueSnapshot")
-    return value.toString()
+    let value = this.get("poolValueSnapshot");
+    return value.toString();
   }
 
   set poolValueSnapshot(value: string) {
-    this.set("poolValueSnapshot", Value.fromString(value))
+    this.set("poolValueSnapshot", Value.fromString(value));
+  }
+
+  get seriesId(): i32 {
+    let value = this.get("seriesId");
+    return value.toI32();
+  }
+
+  set seriesId(value: i32) {
+    this.set("seriesId", Value.fromI32(value));
   }
 }
 
 export class WTokenSold extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save WTokenSold entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save WTokenSold entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save WTokenSold entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("WTokenSold", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("WTokenSold", id.toString(), this);
   }
 
   static load(id: string): WTokenSold | null {
-    return store.get("WTokenSold", id) as WTokenSold | null
+    return store.get("WTokenSold", id) as WTokenSold | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get account(): string {
-    let value = this.get("account")
-    return value.toString()
+    let value = this.get("account");
+    return value.toString();
   }
 
   set account(value: string) {
-    this.set("account", Value.fromString(value))
+    this.set("account", Value.fromString(value));
   }
 
   get collateralAmount(): BigInt {
-    let value = this.get("collateralAmount")
-    return value.toBigInt()
+    let value = this.get("collateralAmount");
+    return value.toBigInt();
   }
 
   set collateralAmount(value: BigInt) {
-    this.set("collateralAmount", Value.fromBigInt(value))
+    this.set("collateralAmount", Value.fromBigInt(value));
   }
 
   get tokenAmount(): BigInt {
-    let value = this.get("tokenAmount")
-    return value.toBigInt()
+    let value = this.get("tokenAmount");
+    return value.toBigInt();
   }
 
   set tokenAmount(value: BigInt) {
-    this.set("tokenAmount", Value.fromBigInt(value))
+    this.set("tokenAmount", Value.fromBigInt(value));
   }
 
   get eventType(): Array<string | null> {
-    let value = this.get("eventType")
-    return value.toStringArray()
+    let value = this.get("eventType");
+    return value.toStringArray();
   }
 
   set eventType(value: Array<string | null>) {
-    this.set("eventType", Value.fromStringArray(value))
+    this.set("eventType", Value.fromStringArray(value));
   }
 
   get amm(): string {
-    let value = this.get("amm")
-    return value.toString()
+    let value = this.get("amm");
+    return value.toString();
   }
 
   set amm(value: string) {
-    this.set("amm", Value.fromString(value))
+    this.set("amm", Value.fromString(value));
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get poolValueSnapshot(): string {
-    let value = this.get("poolValueSnapshot")
-    return value.toString()
+    let value = this.get("poolValueSnapshot");
+    return value.toString();
   }
 
   set poolValueSnapshot(value: string) {
-    this.set("poolValueSnapshot", Value.fromString(value))
+    this.set("poolValueSnapshot", Value.fromString(value));
+  }
+
+  get seriesId(): i32 {
+    let value = this.get("seriesId");
+    return value.toI32();
+  }
+
+  set seriesId(value: i32) {
+    this.set("seriesId", Value.fromI32(value));
   }
 }
 
 export class ERC20AccountBalance extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save ERC20AccountBalance entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save ERC20AccountBalance entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC20AccountBalance entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC20AccountBalance", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC20AccountBalance", id.toString(), this);
   }
 
   static load(id: string): ERC20AccountBalance | null {
-    return store.get("ERC20AccountBalance", id) as ERC20AccountBalance | null
+    return store.get("ERC20AccountBalance", id) as ERC20AccountBalance | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get account(): string {
-    let value = this.get("account")
-    return value.toString()
+    let value = this.get("account");
+    return value.toString();
   }
 
   set account(value: string) {
-    this.set("account", Value.fromString(value))
+    this.set("account", Value.fromString(value));
   }
 
   get token(): string {
-    let value = this.get("token")
-    return value.toString()
+    let value = this.get("token");
+    return value.toString();
   }
 
   set token(value: string) {
-    this.set("token", Value.fromString(value))
+    this.set("token", Value.fromString(value));
   }
 
   get amount(): BigInt {
-    let value = this.get("amount")
-    return value.toBigInt()
+    let value = this.get("amount");
+    return value.toBigInt();
   }
 
   set amount(value: BigInt) {
-    this.set("amount", Value.fromBigInt(value))
+    this.set("amount", Value.fromBigInt(value));
   }
 
   get block(): BigInt | null {
-    let value = this.get("block")
+    let value = this.get("block");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toBigInt()
+      return value.toBigInt();
     }
   }
 
   set block(value: BigInt | null) {
     if (value === null) {
-      this.unset("block")
+      this.unset("block");
     } else {
-      this.set("block", Value.fromBigInt(value as BigInt))
+      this.set("block", Value.fromBigInt(value as BigInt));
     }
   }
 
   get modified(): BigInt | null {
-    let value = this.get("modified")
+    let value = this.get("modified");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toBigInt()
+      return value.toBigInt();
     }
   }
 
   set modified(value: BigInt | null) {
     if (value === null) {
-      this.unset("modified")
+      this.unset("modified");
     } else {
-      this.set("modified", Value.fromBigInt(value as BigInt))
+      this.set("modified", Value.fromBigInt(value as BigInt));
     }
   }
 
   get transaction(): Bytes | null {
-    let value = this.get("transaction")
+    let value = this.get("transaction");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toBytes()
+      return value.toBytes();
     }
   }
 
   set transaction(value: Bytes | null) {
     if (value === null) {
-      this.unset("transaction")
+      this.unset("transaction");
     } else {
-      this.set("transaction", Value.fromBytes(value as Bytes))
+      this.set("transaction", Value.fromBytes(value as Bytes));
     }
   }
 }
 
 export class ERC20AccountBalanceSnapshot extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
+    let id = this.get("id");
     assert(
       id !== null,
-      "Cannot save ERC20AccountBalanceSnapshot entity without an ID",
-    )
+      "Cannot save ERC20AccountBalanceSnapshot entity without an ID"
+    );
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC20AccountBalanceSnapshot entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC20AccountBalanceSnapshot", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC20AccountBalanceSnapshot", id.toString(), this);
   }
 
   static load(id: string): ERC20AccountBalanceSnapshot | null {
     return store.get(
       "ERC20AccountBalanceSnapshot",
-      id,
-    ) as ERC20AccountBalanceSnapshot | null
+      id
+    ) as ERC20AccountBalanceSnapshot | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get account(): string {
-    let value = this.get("account")
-    return value.toString()
+    let value = this.get("account");
+    return value.toString();
   }
 
   set account(value: string) {
-    this.set("account", Value.fromString(value))
+    this.set("account", Value.fromString(value));
   }
 
   get token(): string {
-    let value = this.get("token")
-    return value.toString()
+    let value = this.get("token");
+    return value.toString();
   }
 
   set token(value: string) {
-    this.set("token", Value.fromString(value))
+    this.set("token", Value.fromString(value));
   }
 
   get amount(): BigInt {
-    let value = this.get("amount")
-    return value.toBigInt()
+    let value = this.get("amount");
+    return value.toBigInt();
   }
 
   set amount(value: BigInt) {
-    this.set("amount", Value.fromBigInt(value))
+    this.set("amount", Value.fromBigInt(value));
   }
 
   get event(): string | null {
-    let value = this.get("event")
+    let value = this.get("event");
     if (value === null || value.kind == ValueKind.NULL) {
-      return null
+      return null;
     } else {
-      return value.toString()
+      return value.toString();
     }
   }
 
   set event(value: string | null) {
     if (value === null) {
-      this.unset("event")
+      this.unset("event");
     } else {
-      this.set("event", Value.fromString(value as string))
+      this.set("event", Value.fromString(value as string));
     }
   }
 
   get block(): BigInt {
-    let value = this.get("block")
-    return value.toBigInt()
+    let value = this.get("block");
+    return value.toBigInt();
   }
 
   set block(value: BigInt) {
-    this.set("block", Value.fromBigInt(value))
+    this.set("block", Value.fromBigInt(value));
   }
 
   get timestamp(): BigInt {
-    let value = this.get("timestamp")
-    return value.toBigInt()
+    let value = this.get("timestamp");
+    return value.toBigInt();
   }
 
   set timestamp(value: BigInt) {
-    this.set("timestamp", Value.fromBigInt(value))
+    this.set("timestamp", Value.fromBigInt(value));
   }
 
   get transaction(): Bytes {
-    let value = this.get("transaction")
-    return value.toBytes()
+    let value = this.get("transaction");
+    return value.toBytes();
   }
 
   set transaction(value: Bytes) {
-    this.set("transaction", Value.fromBytes(value))
+    this.set("transaction", Value.fromBytes(value));
   }
 }
 
 export class SettlementPrice extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save SettlementPrice entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save SettlementPrice entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save SettlementPrice entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("SettlementPrice", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("SettlementPrice", id.toString(), this);
   }
 
   static load(id: string): SettlementPrice | null {
-    return store.get("SettlementPrice", id) as SettlementPrice | null
+    return store.get("SettlementPrice", id) as SettlementPrice | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get priceOracleAddress(): Bytes {
-    let value = this.get("priceOracleAddress")
-    return value.toBytes()
+    let value = this.get("priceOracleAddress");
+    return value.toBytes();
   }
 
   set priceOracleAddress(value: Bytes) {
-    this.set("priceOracleAddress", Value.fromBytes(value))
+    this.set("priceOracleAddress", Value.fromBytes(value));
   }
 
   get createdBlock(): BigInt {
-    let value = this.get("createdBlock")
-    return value.toBigInt()
+    let value = this.get("createdBlock");
+    return value.toBigInt();
   }
 
   set createdBlock(value: BigInt) {
-    this.set("createdBlock", Value.fromBigInt(value))
+    this.set("createdBlock", Value.fromBigInt(value));
   }
 
   get createdTimestamp(): BigInt {
-    let value = this.get("createdTimestamp")
-    return value.toBigInt()
+    let value = this.get("createdTimestamp");
+    return value.toBigInt();
   }
 
   set createdTimestamp(value: BigInt) {
-    this.set("createdTimestamp", Value.fromBigInt(value))
+    this.set("createdTimestamp", Value.fromBigInt(value));
   }
 
   get createdTransaction(): Bytes {
-    let value = this.get("createdTransaction")
-    return value.toBytes()
+    let value = this.get("createdTransaction");
+    return value.toBytes();
   }
 
   set createdTransaction(value: Bytes) {
-    this.set("createdTransaction", Value.fromBytes(value))
+    this.set("createdTransaction", Value.fromBytes(value));
   }
 
   get underlyingToken(): Bytes {
-    let value = this.get("underlyingToken")
-    return value.toBytes()
+    let value = this.get("underlyingToken");
+    return value.toBytes();
   }
 
   set underlyingToken(value: Bytes) {
-    this.set("underlyingToken", Value.fromBytes(value))
+    this.set("underlyingToken", Value.fromBytes(value));
   }
 
   get priceToken(): Bytes {
-    let value = this.get("priceToken")
-    return value.toBytes()
+    let value = this.get("priceToken");
+    return value.toBytes();
   }
 
   set priceToken(value: Bytes) {
-    this.set("priceToken", Value.fromBytes(value))
+    this.set("priceToken", Value.fromBytes(value));
   }
 
   get settlementDate(): BigInt {
-    let value = this.get("settlementDate")
-    return value.toBigInt()
+    let value = this.get("settlementDate");
+    return value.toBigInt();
   }
 
   set settlementDate(value: BigInt) {
-    this.set("settlementDate", Value.fromBigInt(value))
+    this.set("settlementDate", Value.fromBigInt(value));
   }
 
   get price(): BigInt {
-    let value = this.get("price")
-    return value.toBigInt()
+    let value = this.get("price");
+    return value.toBigInt();
   }
 
   set price(value: BigInt) {
-    this.set("price", Value.fromBigInt(value))
+    this.set("price", Value.fromBigInt(value));
   }
 }
 
 export class OracleSetting extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save OracleSetting entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save OracleSetting entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save OracleSetting entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("OracleSetting", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("OracleSetting", id.toString(), this);
   }
 
   static load(id: string): OracleSetting | null {
-    return store.get("OracleSetting", id) as OracleSetting | null
+    return store.get("OracleSetting", id) as OracleSetting | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get priceOracleAddress(): Bytes {
-    let value = this.get("priceOracleAddress")
-    return value.toBytes()
+    let value = this.get("priceOracleAddress");
+    return value.toBytes();
   }
 
   set priceOracleAddress(value: Bytes) {
-    this.set("priceOracleAddress", Value.fromBytes(value))
+    this.set("priceOracleAddress", Value.fromBytes(value));
   }
 
   get createdBlock(): BigInt {
-    let value = this.get("createdBlock")
-    return value.toBigInt()
+    let value = this.get("createdBlock");
+    return value.toBigInt();
   }
 
   set createdBlock(value: BigInt) {
-    this.set("createdBlock", Value.fromBigInt(value))
+    this.set("createdBlock", Value.fromBigInt(value));
   }
 
   get createdTimestamp(): BigInt {
-    let value = this.get("createdTimestamp")
-    return value.toBigInt()
+    let value = this.get("createdTimestamp");
+    return value.toBigInt();
   }
 
   set createdTimestamp(value: BigInt) {
-    this.set("createdTimestamp", Value.fromBigInt(value))
+    this.set("createdTimestamp", Value.fromBigInt(value));
   }
 
   get createdTransaction(): Bytes {
-    let value = this.get("createdTransaction")
-    return value.toBytes()
+    let value = this.get("createdTransaction");
+    return value.toBytes();
   }
 
   set createdTransaction(value: Bytes) {
-    this.set("createdTransaction", Value.fromBytes(value))
+    this.set("createdTransaction", Value.fromBytes(value));
   }
 
   get underlyingToken(): Bytes {
-    let value = this.get("underlyingToken")
-    return value.toBytes()
+    let value = this.get("underlyingToken");
+    return value.toBytes();
   }
 
   set underlyingToken(value: Bytes) {
-    this.set("underlyingToken", Value.fromBytes(value))
+    this.set("underlyingToken", Value.fromBytes(value));
   }
 
   get priceToken(): Bytes {
-    let value = this.get("priceToken")
-    return value.toBytes()
+    let value = this.get("priceToken");
+    return value.toBytes();
   }
 
   set priceToken(value: Bytes) {
-    this.set("priceToken", Value.fromBytes(value))
+    this.set("priceToken", Value.fromBytes(value));
   }
 
   get oracle(): Bytes {
-    let value = this.get("oracle")
-    return value.toBytes()
+    let value = this.get("oracle");
+    return value.toBytes();
   }
 
   set oracle(value: Bytes) {
-    this.set("oracle", Value.fromBytes(value))
+    this.set("oracle", Value.fromBytes(value));
   }
 
   get earliestSettlementDate(): BigInt {
-    let value = this.get("earliestSettlementDate")
-    return value.toBigInt()
+    let value = this.get("earliestSettlementDate");
+    return value.toBigInt();
   }
 
   set earliestSettlementDate(value: BigInt) {
-    this.set("earliestSettlementDate", Value.fromBigInt(value))
+    this.set("earliestSettlementDate", Value.fromBigInt(value));
   }
 }
 
 export class SeriesVault extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save SeriesVault entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save SeriesVault entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save SeriesVault entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("SeriesVault", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("SeriesVault", id.toString(), this);
   }
 
   static load(id: string): SeriesVault | null {
-    return store.get("SeriesVault", id) as SeriesVault | null
+    return store.get("SeriesVault", id) as SeriesVault | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get createdBlock(): BigInt {
-    let value = this.get("createdBlock")
-    return value.toBigInt()
+    let value = this.get("createdBlock");
+    return value.toBigInt();
   }
 
   set createdBlock(value: BigInt) {
-    this.set("createdBlock", Value.fromBigInt(value))
+    this.set("createdBlock", Value.fromBigInt(value));
   }
 
   get createdTimestamp(): BigInt {
-    let value = this.get("createdTimestamp")
-    return value.toBigInt()
+    let value = this.get("createdTimestamp");
+    return value.toBigInt();
   }
 
   set createdTimestamp(value: BigInt) {
-    this.set("createdTimestamp", Value.fromBigInt(value))
+    this.set("createdTimestamp", Value.fromBigInt(value));
   }
 
   get createdTransaction(): Bytes {
-    let value = this.get("createdTransaction")
-    return value.toBytes()
+    let value = this.get("createdTransaction");
+    return value.toBytes();
   }
 
   set createdTransaction(value: Bytes) {
-    this.set("createdTransaction", Value.fromBytes(value))
+    this.set("createdTransaction", Value.fromBytes(value));
   }
 
   get controller(): Bytes {
-    let value = this.get("controller")
-    return value.toBytes()
+    let value = this.get("controller");
+    return value.toBytes();
   }
 
   set controller(value: Bytes) {
-    this.set("controller", Value.fromBytes(value))
+    this.set("controller", Value.fromBytes(value));
   }
 }
 
 export class ERC1155Controller extends Entity {
   constructor(id: string) {
-    super()
-    this.set("id", Value.fromString(id))
+    super();
+    this.set("id", Value.fromString(id));
   }
 
   save(): void {
-    let id = this.get("id")
-    assert(id !== null, "Cannot save ERC1155Controller entity without an ID")
+    let id = this.get("id");
+    assert(id !== null, "Cannot save ERC1155Controller entity without an ID");
     assert(
       id.kind == ValueKind.STRING,
       "Cannot save ERC1155Controller entity with non-string ID. " +
-        'Considering using .toHex() to convert the "id" to a string.',
-    )
-    store.set("ERC1155Controller", id.toString(), this)
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ERC1155Controller", id.toString(), this);
   }
 
   static load(id: string): ERC1155Controller | null {
-    return store.get("ERC1155Controller", id) as ERC1155Controller | null
+    return store.get("ERC1155Controller", id) as ERC1155Controller | null;
   }
 
   get id(): string {
-    let value = this.get("id")
-    return value.toString()
+    let value = this.get("id");
+    return value.toString();
   }
 
   set id(value: string) {
-    this.set("id", Value.fromString(value))
+    this.set("id", Value.fromString(value));
   }
 
   get createdBlock(): BigInt {
-    let value = this.get("createdBlock")
-    return value.toBigInt()
+    let value = this.get("createdBlock");
+    return value.toBigInt();
   }
 
   set createdBlock(value: BigInt) {
-    this.set("createdBlock", Value.fromBigInt(value))
+    this.set("createdBlock", Value.fromBigInt(value));
   }
 
   get createdTimestamp(): BigInt {
-    let value = this.get("createdTimestamp")
-    return value.toBigInt()
+    let value = this.get("createdTimestamp");
+    return value.toBigInt();
   }
 
   set createdTimestamp(value: BigInt) {
-    this.set("createdTimestamp", Value.fromBigInt(value))
+    this.set("createdTimestamp", Value.fromBigInt(value));
   }
 
   get createdTransaction(): Bytes {
-    let value = this.get("createdTransaction")
-    return value.toBytes()
+    let value = this.get("createdTransaction");
+    return value.toBytes();
   }
 
   set createdTransaction(value: Bytes) {
-    this.set("createdTransaction", Value.fromBytes(value))
+    this.set("createdTransaction", Value.fromBytes(value));
   }
 
   get uri(): string {
-    let value = this.get("uri")
-    return value.toString()
+    let value = this.get("uri");
+    return value.toString();
   }
 
   set uri(value: string) {
-    this.set("uri", Value.fromString(value))
+    this.set("uri", Value.fromString(value));
   }
 
   get controller(): Bytes {
-    let value = this.get("controller")
-    return value.toBytes()
+    let value = this.get("controller");
+    return value.toBytes();
   }
 
   set controller(value: Bytes) {
-    this.set("controller", Value.fromBytes(value))
+    this.set("controller", Value.fromBytes(value));
   }
 }

--- a/subgraph/generated/templates/Amm/MinterAmm.ts
+++ b/subgraph/generated/templates/Amm/MinterAmm.ts
@@ -7,352 +7,352 @@ import {
   Entity,
   Bytes,
   Address,
-  BigInt,
-} from "@graphprotocol/graph-ts"
+  BigInt
+} from "@graphprotocol/graph-ts";
 
 export class AMMInitialized extends ethereum.Event {
   get params(): AMMInitialized__Params {
-    return new AMMInitialized__Params(this)
+    return new AMMInitialized__Params(this);
   }
 }
 
 export class AMMInitialized__Params {
-  _event: AMMInitialized
+  _event: AMMInitialized;
 
   constructor(event: AMMInitialized) {
-    this._event = event
+    this._event = event;
   }
 
   get lpToken(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get sirenPriceOracle(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get controller(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class BTokensBought extends ethereum.Event {
   get params(): BTokensBought__Params {
-    return new BTokensBought__Params(this)
+    return new BTokensBought__Params(this);
   }
 }
 
 export class BTokensBought__Params {
-  _event: BTokensBought
+  _event: BTokensBought;
 
   constructor(event: BTokensBought) {
-    this._event = event
+    this._event = event;
   }
 
   get buyer(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get bTokensBought(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 
   get collateralPaid(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 }
 
 export class BTokensSold extends ethereum.Event {
   get params(): BTokensSold__Params {
-    return new BTokensSold__Params(this)
+    return new BTokensSold__Params(this);
   }
 }
 
 export class BTokensSold__Params {
-  _event: BTokensSold
+  _event: BTokensSold;
 
   constructor(event: BTokensSold) {
-    this._event = event
+    this._event = event;
   }
 
   get seller(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get bTokensSold(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 
   get collateralPaid(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 }
 
 export class CodeAddressUpdated extends ethereum.Event {
   get params(): CodeAddressUpdated__Params {
-    return new CodeAddressUpdated__Params(this)
+    return new CodeAddressUpdated__Params(this);
   }
 }
 
 export class CodeAddressUpdated__Params {
-  _event: CodeAddressUpdated
+  _event: CodeAddressUpdated;
 
   constructor(event: CodeAddressUpdated) {
-    this._event = event
+    this._event = event;
   }
 
   get newAddress(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class LpTokensBurned extends ethereum.Event {
   get params(): LpTokensBurned__Params {
-    return new LpTokensBurned__Params(this)
+    return new LpTokensBurned__Params(this);
   }
 }
 
 export class LpTokensBurned__Params {
-  _event: LpTokensBurned
+  _event: LpTokensBurned;
 
   constructor(event: LpTokensBurned) {
-    this._event = event
+    this._event = event;
   }
 
   get redeemer(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get collateralRemoved(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get lpTokensBurned(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class LpTokensMinted extends ethereum.Event {
   get params(): LpTokensMinted__Params {
-    return new LpTokensMinted__Params(this)
+    return new LpTokensMinted__Params(this);
   }
 }
 
 export class LpTokensMinted__Params {
-  _event: LpTokensMinted
+  _event: LpTokensMinted;
 
   constructor(event: LpTokensMinted) {
-    this._event = event
+    this._event = event;
   }
 
   get minter(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get collateralAdded(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get lpTokensMinted(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class NewSirenPriceOracle extends ethereum.Event {
   get params(): NewSirenPriceOracle__Params {
-    return new NewSirenPriceOracle__Params(this)
+    return new NewSirenPriceOracle__Params(this);
   }
 }
 
 export class NewSirenPriceOracle__Params {
-  _event: NewSirenPriceOracle
+  _event: NewSirenPriceOracle;
 
   constructor(event: NewSirenPriceOracle) {
-    this._event = event
+    this._event = event;
   }
 
   get newSirenPriceOracle(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 }
 
 export class OwnershipTransferred extends ethereum.Event {
   get params(): OwnershipTransferred__Params {
-    return new OwnershipTransferred__Params(this)
+    return new OwnershipTransferred__Params(this);
   }
 }
 
 export class OwnershipTransferred__Params {
-  _event: OwnershipTransferred
+  _event: OwnershipTransferred;
 
   constructor(event: OwnershipTransferred) {
-    this._event = event
+    this._event = event;
   }
 
   get previousOwner(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get newOwner(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 }
 
 export class SeriesEvicted extends ethereum.Event {
   get params(): SeriesEvicted__Params {
-    return new SeriesEvicted__Params(this)
+    return new SeriesEvicted__Params(this);
   }
 }
 
 export class SeriesEvicted__Params {
-  _event: SeriesEvicted
+  _event: SeriesEvicted;
 
   constructor(event: SeriesEvicted) {
-    this._event = event
+    this._event = event;
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[0].value.toBigInt()
+    return this._event.parameters[0].value.toBigInt();
   }
 }
 
 export class VolatilityFactorUpdated extends ethereum.Event {
   get params(): VolatilityFactorUpdated__Params {
-    return new VolatilityFactorUpdated__Params(this)
+    return new VolatilityFactorUpdated__Params(this);
   }
 }
 
 export class VolatilityFactorUpdated__Params {
-  _event: VolatilityFactorUpdated
+  _event: VolatilityFactorUpdated;
 
   constructor(event: VolatilityFactorUpdated) {
-    this._event = event
+    this._event = event;
   }
 
   get newVolatilityFactor(): BigInt {
-    return this._event.parameters[0].value.toBigInt()
+    return this._event.parameters[0].value.toBigInt();
   }
 }
 
 export class WTokensSold extends ethereum.Event {
   get params(): WTokensSold__Params {
-    return new WTokensSold__Params(this)
+    return new WTokensSold__Params(this);
   }
 }
 
 export class WTokensSold__Params {
-  _event: WTokensSold
+  _event: WTokensSold;
 
   constructor(event: WTokensSold) {
-    this._event = event
+    this._event = event;
   }
 
   get seller(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get seriesId(): BigInt {
-    return this._event.parameters[1].value.toBigInt()
+    return this._event.parameters[1].value.toBigInt();
   }
 
   get wTokensSold(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 
   get collateralPaid(): BigInt {
-    return this._event.parameters[3].value.toBigInt()
+    return this._event.parameters[3].value.toBigInt();
   }
 }
 
 export class MinterAmm__getSeriesResultValue0Struct extends ethereum.Tuple {
   get expirationDate(): BigInt {
-    return this[0].toBigInt()
+    return this[0].toBigInt();
   }
 
   get isPutOption(): boolean {
-    return this[1].toBoolean()
+    return this[1].toBoolean();
   }
 
   get tokens(): MinterAmm__getSeriesResultValue0TokensStruct {
-    return this[2].toTuple() as MinterAmm__getSeriesResultValue0TokensStruct
+    return this[2].toTuple() as MinterAmm__getSeriesResultValue0TokensStruct;
   }
 
   get strikePrice(): BigInt {
-    return this[3].toBigInt()
+    return this[3].toBigInt();
   }
 }
 
 export class MinterAmm__getSeriesResultValue0TokensStruct extends ethereum.Tuple {
   get underlyingToken(): Address {
-    return this[0].toAddress()
+    return this[0].toAddress();
   }
 
   get priceToken(): Address {
-    return this[1].toAddress()
+    return this[1].toAddress();
   }
 
   get collateralToken(): Address {
-    return this[2].toAddress()
+    return this[2].toAddress();
   }
 }
 
 export class MinterAmm__getVirtualReservesResult {
-  value0: BigInt
-  value1: BigInt
+  value0: BigInt;
+  value1: BigInt;
 
   constructor(value0: BigInt, value1: BigInt) {
-    this.value0 = value0
-    this.value1 = value1
+    this.value0 = value0;
+    this.value1 = value1;
   }
 
   toMap(): TypedMap<string, ethereum.Value> {
-    let map = new TypedMap<string, ethereum.Value>()
-    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0))
-    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1))
-    return map
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    return map;
   }
 }
 
 export class MinterAmm extends ethereum.SmartContract {
   static bind(address: Address): MinterAmm {
-    return new MinterAmm("MinterAmm", address)
+    return new MinterAmm("MinterAmm", address);
   }
 
   MINIMUM_TRADE_SIZE(): BigInt {
     let result = super.call(
       "MINIMUM_TRADE_SIZE",
       "MINIMUM_TRADE_SIZE():(uint256)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_MINIMUM_TRADE_SIZE(): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "MINIMUM_TRADE_SIZE",
       "MINIMUM_TRADE_SIZE():(uint256)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   bTokenBuy(
     seriesId: BigInt,
     bTokenAmount: BigInt,
-    collateralMaximum: BigInt,
+    collateralMaximum: BigInt
   ): BigInt {
     let result = super.call(
       "bTokenBuy",
@@ -360,17 +360,17 @@ export class MinterAmm extends ethereum.SmartContract {
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
         ethereum.Value.fromUnsignedBigInt(bTokenAmount),
-        ethereum.Value.fromUnsignedBigInt(collateralMaximum),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(collateralMaximum)
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_bTokenBuy(
     seriesId: BigInt,
     bTokenAmount: BigInt,
-    collateralMaximum: BigInt,
+    collateralMaximum: BigInt
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "bTokenBuy",
@@ -378,14 +378,14 @@ export class MinterAmm extends ethereum.SmartContract {
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
         ethereum.Value.fromUnsignedBigInt(bTokenAmount),
-        ethereum.Value.fromUnsignedBigInt(collateralMaximum),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(collateralMaximum)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   bTokenGetCollateralIn(seriesId: BigInt, bTokenAmount: BigInt): BigInt {
@@ -394,30 +394,30 @@ export class MinterAmm extends ethereum.SmartContract {
       "bTokenGetCollateralIn(uint64,uint256):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
-        ethereum.Value.fromUnsignedBigInt(bTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(bTokenAmount)
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_bTokenGetCollateralIn(
     seriesId: BigInt,
-    bTokenAmount: BigInt,
+    bTokenAmount: BigInt
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "bTokenGetCollateralIn",
       "bTokenGetCollateralIn(uint64,uint256):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
-        ethereum.Value.fromUnsignedBigInt(bTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(bTokenAmount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   bTokenGetCollateralOut(seriesId: BigInt, bTokenAmount: BigInt): BigInt {
@@ -426,36 +426,36 @@ export class MinterAmm extends ethereum.SmartContract {
       "bTokenGetCollateralOut(uint64,uint256):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
-        ethereum.Value.fromUnsignedBigInt(bTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(bTokenAmount)
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_bTokenGetCollateralOut(
     seriesId: BigInt,
-    bTokenAmount: BigInt,
+    bTokenAmount: BigInt
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "bTokenGetCollateralOut",
       "bTokenGetCollateralOut(uint64,uint256):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
-        ethereum.Value.fromUnsignedBigInt(bTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(bTokenAmount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   bTokenSell(
     seriesId: BigInt,
     bTokenAmount: BigInt,
-    collateralMinimum: BigInt,
+    collateralMinimum: BigInt
   ): BigInt {
     let result = super.call(
       "bTokenSell",
@@ -463,17 +463,17 @@ export class MinterAmm extends ethereum.SmartContract {
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
         ethereum.Value.fromUnsignedBigInt(bTokenAmount),
-        ethereum.Value.fromUnsignedBigInt(collateralMinimum),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(collateralMinimum)
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_bTokenSell(
     seriesId: BigInt,
     bTokenAmount: BigInt,
-    collateralMinimum: BigInt,
+    collateralMinimum: BigInt
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "bTokenSell",
@@ -481,14 +481,14 @@ export class MinterAmm extends ethereum.SmartContract {
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
         ethereum.Value.fromUnsignedBigInt(bTokenAmount),
-        ethereum.Value.fromUnsignedBigInt(collateralMinimum),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(collateralMinimum)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   calcPrice(
@@ -496,7 +496,7 @@ export class MinterAmm extends ethereum.SmartContract {
     strike: BigInt,
     currentPrice: BigInt,
     volatility: BigInt,
-    isPutOption: boolean,
+    isPutOption: boolean
   ): BigInt {
     let result = super.call(
       "calcPrice",
@@ -506,11 +506,11 @@ export class MinterAmm extends ethereum.SmartContract {
         ethereum.Value.fromUnsignedBigInt(strike),
         ethereum.Value.fromUnsignedBigInt(currentPrice),
         ethereum.Value.fromUnsignedBigInt(volatility),
-        ethereum.Value.fromBoolean(isPutOption),
-      ],
-    )
+        ethereum.Value.fromBoolean(isPutOption)
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_calcPrice(
@@ -518,7 +518,7 @@ export class MinterAmm extends ethereum.SmartContract {
     strike: BigInt,
     currentPrice: BigInt,
     volatility: BigInt,
-    isPutOption: boolean,
+    isPutOption: boolean
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "calcPrice",
@@ -528,85 +528,85 @@ export class MinterAmm extends ethereum.SmartContract {
         ethereum.Value.fromUnsignedBigInt(strike),
         ethereum.Value.fromUnsignedBigInt(currentPrice),
         ethereum.Value.fromUnsignedBigInt(volatility),
-        ethereum.Value.fromBoolean(isPutOption),
-      ],
-    )
+        ethereum.Value.fromBoolean(isPutOption)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   collateralToken(): Address {
     let result = super.call(
       "collateralToken",
       "collateralToken():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_collateralToken(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "collateralToken",
       "collateralToken():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   erc1155Controller(): Address {
     let result = super.call(
       "erc1155Controller",
       "erc1155Controller():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_erc1155Controller(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "erc1155Controller",
       "erc1155Controller():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   getAllSeries(): Array<BigInt> {
-    let result = super.call("getAllSeries", "getAllSeries():(uint64[])", [])
+    let result = super.call("getAllSeries", "getAllSeries():(uint64[])", []);
 
-    return result[0].toBigIntArray()
+    return result[0].toBigIntArray();
   }
 
   try_getAllSeries(): ethereum.CallResult<Array<BigInt>> {
-    let result = super.tryCall("getAllSeries", "getAllSeries():(uint64[])", [])
+    let result = super.tryCall("getAllSeries", "getAllSeries():(uint64[])", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigIntArray())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigIntArray());
   }
 
   getCollateralValueOfAllExpiredOptionTokens(): BigInt {
     let result = super.call(
       "getCollateralValueOfAllExpiredOptionTokens",
       "getCollateralValueOfAllExpiredOptionTokens():(uint256)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_getCollateralValueOfAllExpiredOptionTokens(): ethereum.CallResult<
@@ -615,184 +615,184 @@ export class MinterAmm extends ethereum.SmartContract {
     let result = super.tryCall(
       "getCollateralValueOfAllExpiredOptionTokens",
       "getCollateralValueOfAllExpiredOptionTokens():(uint256)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getLogicAddress(): Address {
     let result = super.call(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_getLogicAddress(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "getLogicAddress",
       "getLogicAddress():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   getOptionTokensSaleValue(lpTokenAmount: BigInt): BigInt {
     let result = super.call(
       "getOptionTokensSaleValue",
       "getOptionTokensSaleValue(uint256):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(lpTokenAmount)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(lpTokenAmount)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_getOptionTokensSaleValue(
-    lpTokenAmount: BigInt,
+    lpTokenAmount: BigInt
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "getOptionTokensSaleValue",
       "getOptionTokensSaleValue(uint256):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(lpTokenAmount)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(lpTokenAmount)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getPriceForSeries(seriesId: BigInt): BigInt {
     let result = super.call(
       "getPriceForSeries",
       "getPriceForSeries(uint64):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(seriesId)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_getPriceForSeries(seriesId: BigInt): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "getPriceForSeries",
       "getPriceForSeries(uint64):(uint256)",
-      [ethereum.Value.fromUnsignedBigInt(seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getSeries(seriesId: BigInt): MinterAmm__getSeriesResultValue0Struct {
     let result = super.call(
       "getSeries",
       "getSeries(uint64):((uint40,bool,(address,address,address),uint256))",
-      [ethereum.Value.fromUnsignedBigInt(seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(seriesId)]
+    );
 
-    return result[0].toTuple() as MinterAmm__getSeriesResultValue0Struct
+    return result[0].toTuple() as MinterAmm__getSeriesResultValue0Struct;
   }
 
   try_getSeries(
-    seriesId: BigInt,
+    seriesId: BigInt
   ): ethereum.CallResult<MinterAmm__getSeriesResultValue0Struct> {
     let result = super.tryCall(
       "getSeries",
       "getSeries(uint64):((uint40,bool,(address,address,address),uint256))",
-      [ethereum.Value.fromUnsignedBigInt(seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
+    let value = result.value;
     return ethereum.CallResult.fromValue(
-      value[0].toTuple() as MinterAmm__getSeriesResultValue0Struct,
-    )
+      value[0].toTuple() as MinterAmm__getSeriesResultValue0Struct
+    );
   }
 
   getTotalPoolValue(includeUnclaimed: boolean): BigInt {
     let result = super.call(
       "getTotalPoolValue",
       "getTotalPoolValue(bool):(uint256)",
-      [ethereum.Value.fromBoolean(includeUnclaimed)],
-    )
+      [ethereum.Value.fromBoolean(includeUnclaimed)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_getTotalPoolValue(
-    includeUnclaimed: boolean,
+    includeUnclaimed: boolean
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "getTotalPoolValue",
       "getTotalPoolValue(bool):(uint256)",
-      [ethereum.Value.fromBoolean(includeUnclaimed)],
-    )
+      [ethereum.Value.fromBoolean(includeUnclaimed)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getVirtualReserves(seriesId: BigInt): MinterAmm__getVirtualReservesResult {
     let result = super.call(
       "getVirtualReserves",
       "getVirtualReserves(uint64):(uint256,uint256)",
-      [ethereum.Value.fromUnsignedBigInt(seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(seriesId)]
+    );
 
     return new MinterAmm__getVirtualReservesResult(
       result[0].toBigInt(),
-      result[1].toBigInt(),
-    )
+      result[1].toBigInt()
+    );
   }
 
   try_getVirtualReserves(
-    seriesId: BigInt,
+    seriesId: BigInt
   ): ethereum.CallResult<MinterAmm__getVirtualReservesResult> {
     let result = super.tryCall(
       "getVirtualReserves",
       "getVirtualReserves(uint64):(uint256,uint256)",
-      [ethereum.Value.fromUnsignedBigInt(seriesId)],
-    )
+      [ethereum.Value.fromUnsignedBigInt(seriesId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
+    let value = result.value;
     return ethereum.CallResult.fromValue(
       new MinterAmm__getVirtualReservesResult(
         value[0].toBigInt(),
-        value[1].toBigInt(),
-      ),
-    )
+        value[1].toBigInt()
+      )
+    );
   }
 
   lpToken(): Address {
-    let result = super.call("lpToken", "lpToken():(address)", [])
+    let result = super.call("lpToken", "lpToken():(address)", []);
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_lpToken(): ethereum.CallResult<Address> {
-    let result = super.tryCall("lpToken", "lpToken():(address)", [])
+    let result = super.tryCall("lpToken", "lpToken():(address)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   onERC1155BatchReceived(
@@ -800,7 +800,7 @@ export class MinterAmm extends ethereum.SmartContract {
     param1: Address,
     param2: Array<BigInt>,
     param3: Array<BigInt>,
-    param4: Bytes,
+    param4: Bytes
   ): Bytes {
     let result = super.call(
       "onERC1155BatchReceived",
@@ -810,11 +810,11 @@ export class MinterAmm extends ethereum.SmartContract {
         ethereum.Value.fromAddress(param1),
         ethereum.Value.fromUnsignedBigIntArray(param2),
         ethereum.Value.fromUnsignedBigIntArray(param3),
-        ethereum.Value.fromBytes(param4),
-      ],
-    )
+        ethereum.Value.fromBytes(param4)
+      ]
+    );
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_onERC1155BatchReceived(
@@ -822,7 +822,7 @@ export class MinterAmm extends ethereum.SmartContract {
     param1: Address,
     param2: Array<BigInt>,
     param3: Array<BigInt>,
-    param4: Bytes,
+    param4: Bytes
   ): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "onERC1155BatchReceived",
@@ -832,14 +832,14 @@ export class MinterAmm extends ethereum.SmartContract {
         ethereum.Value.fromAddress(param1),
         ethereum.Value.fromUnsignedBigIntArray(param2),
         ethereum.Value.fromUnsignedBigIntArray(param3),
-        ethereum.Value.fromBytes(param4),
-      ],
-    )
+        ethereum.Value.fromBytes(param4)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   onERC1155Received(
@@ -847,7 +847,7 @@ export class MinterAmm extends ethereum.SmartContract {
     param1: Address,
     param2: BigInt,
     param3: BigInt,
-    param4: Bytes,
+    param4: Bytes
   ): Bytes {
     let result = super.call(
       "onERC1155Received",
@@ -857,11 +857,11 @@ export class MinterAmm extends ethereum.SmartContract {
         ethereum.Value.fromAddress(param1),
         ethereum.Value.fromUnsignedBigInt(param2),
         ethereum.Value.fromUnsignedBigInt(param3),
-        ethereum.Value.fromBytes(param4),
-      ],
-    )
+        ethereum.Value.fromBytes(param4)
+      ]
+    );
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_onERC1155Received(
@@ -869,7 +869,7 @@ export class MinterAmm extends ethereum.SmartContract {
     param1: Address,
     param2: BigInt,
     param3: BigInt,
-    param4: Bytes,
+    param4: Bytes
   ): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "onERC1155Received",
@@ -879,174 +879,178 @@ export class MinterAmm extends ethereum.SmartContract {
         ethereum.Value.fromAddress(param1),
         ethereum.Value.fromUnsignedBigInt(param2),
         ethereum.Value.fromUnsignedBigInt(param3),
-        ethereum.Value.fromBytes(param4),
-      ],
-    )
+        ethereum.Value.fromBytes(param4)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   owner(): Address {
-    let result = super.call("owner", "owner():(address)", [])
+    let result = super.call("owner", "owner():(address)", []);
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_owner(): ethereum.CallResult<Address> {
-    let result = super.tryCall("owner", "owner():(address)", [])
+    let result = super.tryCall("owner", "owner():(address)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   priceToken(): Address {
-    let result = super.call("priceToken", "priceToken():(address)", [])
+    let result = super.call("priceToken", "priceToken():(address)", []);
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_priceToken(): ethereum.CallResult<Address> {
-    let result = super.tryCall("priceToken", "priceToken():(address)", [])
+    let result = super.tryCall("priceToken", "priceToken():(address)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   proxiableUUID(): Bytes {
-    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.call("proxiableUUID", "proxiableUUID():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_proxiableUUID(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("proxiableUUID", "proxiableUUID():(bytes32)", [])
+    let result = super.tryCall(
+      "proxiableUUID",
+      "proxiableUUID():(bytes32)",
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   seriesController(): Address {
     let result = super.call(
       "seriesController",
       "seriesController():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_seriesController(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "seriesController",
       "seriesController():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   supportsInterface(interfaceId: Bytes): boolean {
     let result = super.call(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_supportsInterface(interfaceId: Bytes): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   tradeFeeBasisPoints(): i32 {
     let result = super.call(
       "tradeFeeBasisPoints",
       "tradeFeeBasisPoints():(uint16)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_tradeFeeBasisPoints(): ethereum.CallResult<i32> {
     let result = super.tryCall(
       "tradeFeeBasisPoints",
       "tradeFeeBasisPoints():(uint16)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   underlyingToken(): Address {
     let result = super.call(
       "underlyingToken",
       "underlyingToken():(address)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toAddress()
+    return result[0].toAddress();
   }
 
   try_underlyingToken(): ethereum.CallResult<Address> {
     let result = super.tryCall(
       "underlyingToken",
       "underlyingToken():(address)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toAddress())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
   volatilityFactor(): BigInt {
     let result = super.call(
       "volatilityFactor",
       "volatilityFactor():(uint256)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_volatilityFactor(): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "volatilityFactor",
       "volatilityFactor():(uint256)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   wTokenGetCollateralOut(seriesId: BigInt, wTokenAmount: BigInt): BigInt {
@@ -1055,36 +1059,36 @@ export class MinterAmm extends ethereum.SmartContract {
       "wTokenGetCollateralOut(uint64,uint256):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
-        ethereum.Value.fromUnsignedBigInt(wTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(wTokenAmount)
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_wTokenGetCollateralOut(
     seriesId: BigInt,
-    wTokenAmount: BigInt,
+    wTokenAmount: BigInt
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "wTokenGetCollateralOut",
       "wTokenGetCollateralOut(uint64,uint256):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
-        ethereum.Value.fromUnsignedBigInt(wTokenAmount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(wTokenAmount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   wTokenSell(
     seriesId: BigInt,
     wTokenAmount: BigInt,
-    collateralMinimum: BigInt,
+    collateralMinimum: BigInt
   ): BigInt {
     let result = super.call(
       "wTokenSell",
@@ -1092,17 +1096,17 @@ export class MinterAmm extends ethereum.SmartContract {
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
         ethereum.Value.fromUnsignedBigInt(wTokenAmount),
-        ethereum.Value.fromUnsignedBigInt(collateralMinimum),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(collateralMinimum)
+      ]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_wTokenSell(
     seriesId: BigInt,
     wTokenAmount: BigInt,
-    collateralMinimum: BigInt,
+    collateralMinimum: BigInt
   ): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "wTokenSell",
@@ -1110,567 +1114,567 @@ export class MinterAmm extends ethereum.SmartContract {
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
         ethereum.Value.fromUnsignedBigInt(wTokenAmount),
-        ethereum.Value.fromUnsignedBigInt(collateralMinimum),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(collateralMinimum)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 }
 
 export class AddSeriesCall extends ethereum.Call {
   get inputs(): AddSeriesCall__Inputs {
-    return new AddSeriesCall__Inputs(this)
+    return new AddSeriesCall__Inputs(this);
   }
 
   get outputs(): AddSeriesCall__Outputs {
-    return new AddSeriesCall__Outputs(this)
+    return new AddSeriesCall__Outputs(this);
   }
 }
 
 export class AddSeriesCall__Inputs {
-  _call: AddSeriesCall
+  _call: AddSeriesCall;
 
   constructor(call: AddSeriesCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 }
 
 export class AddSeriesCall__Outputs {
-  _call: AddSeriesCall
+  _call: AddSeriesCall;
 
   constructor(call: AddSeriesCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class BTokenBuyCall extends ethereum.Call {
   get inputs(): BTokenBuyCall__Inputs {
-    return new BTokenBuyCall__Inputs(this)
+    return new BTokenBuyCall__Inputs(this);
   }
 
   get outputs(): BTokenBuyCall__Outputs {
-    return new BTokenBuyCall__Outputs(this)
+    return new BTokenBuyCall__Outputs(this);
   }
 }
 
 export class BTokenBuyCall__Inputs {
-  _call: BTokenBuyCall
+  _call: BTokenBuyCall;
 
   constructor(call: BTokenBuyCall) {
-    this._call = call
+    this._call = call;
   }
 
   get seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get bTokenAmount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 
   get collateralMaximum(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 }
 
 export class BTokenBuyCall__Outputs {
-  _call: BTokenBuyCall
+  _call: BTokenBuyCall;
 
   constructor(call: BTokenBuyCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): BigInt {
-    return this._call.outputValues[0].value.toBigInt()
+    return this._call.outputValues[0].value.toBigInt();
   }
 }
 
 export class BTokenSellCall extends ethereum.Call {
   get inputs(): BTokenSellCall__Inputs {
-    return new BTokenSellCall__Inputs(this)
+    return new BTokenSellCall__Inputs(this);
   }
 
   get outputs(): BTokenSellCall__Outputs {
-    return new BTokenSellCall__Outputs(this)
+    return new BTokenSellCall__Outputs(this);
   }
 }
 
 export class BTokenSellCall__Inputs {
-  _call: BTokenSellCall
+  _call: BTokenSellCall;
 
   constructor(call: BTokenSellCall) {
-    this._call = call
+    this._call = call;
   }
 
   get seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get bTokenAmount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 
   get collateralMinimum(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 }
 
 export class BTokenSellCall__Outputs {
-  _call: BTokenSellCall
+  _call: BTokenSellCall;
 
   constructor(call: BTokenSellCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): BigInt {
-    return this._call.outputValues[0].value.toBigInt()
+    return this._call.outputValues[0].value.toBigInt();
   }
 }
 
 export class ClaimAllExpiredTokensCall extends ethereum.Call {
   get inputs(): ClaimAllExpiredTokensCall__Inputs {
-    return new ClaimAllExpiredTokensCall__Inputs(this)
+    return new ClaimAllExpiredTokensCall__Inputs(this);
   }
 
   get outputs(): ClaimAllExpiredTokensCall__Outputs {
-    return new ClaimAllExpiredTokensCall__Outputs(this)
+    return new ClaimAllExpiredTokensCall__Outputs(this);
   }
 }
 
 export class ClaimAllExpiredTokensCall__Inputs {
-  _call: ClaimAllExpiredTokensCall
+  _call: ClaimAllExpiredTokensCall;
 
   constructor(call: ClaimAllExpiredTokensCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class ClaimAllExpiredTokensCall__Outputs {
-  _call: ClaimAllExpiredTokensCall
+  _call: ClaimAllExpiredTokensCall;
 
   constructor(call: ClaimAllExpiredTokensCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class ClaimExpiredTokensCall extends ethereum.Call {
   get inputs(): ClaimExpiredTokensCall__Inputs {
-    return new ClaimExpiredTokensCall__Inputs(this)
+    return new ClaimExpiredTokensCall__Inputs(this);
   }
 
   get outputs(): ClaimExpiredTokensCall__Outputs {
-    return new ClaimExpiredTokensCall__Outputs(this)
+    return new ClaimExpiredTokensCall__Outputs(this);
   }
 }
 
 export class ClaimExpiredTokensCall__Inputs {
-  _call: ClaimExpiredTokensCall
+  _call: ClaimExpiredTokensCall;
 
   constructor(call: ClaimExpiredTokensCall) {
-    this._call = call
+    this._call = call;
   }
 
   get seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 }
 
 export class ClaimExpiredTokensCall__Outputs {
-  _call: ClaimExpiredTokensCall
+  _call: ClaimExpiredTokensCall;
 
   constructor(call: ClaimExpiredTokensCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class InitializeCall extends ethereum.Call {
   get inputs(): InitializeCall__Inputs {
-    return new InitializeCall__Inputs(this)
+    return new InitializeCall__Inputs(this);
   }
 
   get outputs(): InitializeCall__Outputs {
-    return new InitializeCall__Outputs(this)
+    return new InitializeCall__Outputs(this);
   }
 }
 
 export class InitializeCall__Inputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _seriesController(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get _sirenPriceOracle(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get _underlyingToken(): Address {
-    return this._call.inputValues[2].value.toAddress()
+    return this._call.inputValues[2].value.toAddress();
   }
 
   get _priceToken(): Address {
-    return this._call.inputValues[3].value.toAddress()
+    return this._call.inputValues[3].value.toAddress();
   }
 
   get _collateralToken(): Address {
-    return this._call.inputValues[4].value.toAddress()
+    return this._call.inputValues[4].value.toAddress();
   }
 
   get _tokenImplementation(): Address {
-    return this._call.inputValues[5].value.toAddress()
+    return this._call.inputValues[5].value.toAddress();
   }
 
   get _tradeFeeBasisPoints(): i32 {
-    return this._call.inputValues[6].value.toI32()
+    return this._call.inputValues[6].value.toI32();
   }
 }
 
 export class InitializeCall__Outputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class OnERC1155BatchReceivedCall extends ethereum.Call {
   get inputs(): OnERC1155BatchReceivedCall__Inputs {
-    return new OnERC1155BatchReceivedCall__Inputs(this)
+    return new OnERC1155BatchReceivedCall__Inputs(this);
   }
 
   get outputs(): OnERC1155BatchReceivedCall__Outputs {
-    return new OnERC1155BatchReceivedCall__Outputs(this)
+    return new OnERC1155BatchReceivedCall__Outputs(this);
   }
 }
 
 export class OnERC1155BatchReceivedCall__Inputs {
-  _call: OnERC1155BatchReceivedCall
+  _call: OnERC1155BatchReceivedCall;
 
   constructor(call: OnERC1155BatchReceivedCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get value1(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get value2(): Array<BigInt> {
-    return this._call.inputValues[2].value.toBigIntArray()
+    return this._call.inputValues[2].value.toBigIntArray();
   }
 
   get value3(): Array<BigInt> {
-    return this._call.inputValues[3].value.toBigIntArray()
+    return this._call.inputValues[3].value.toBigIntArray();
   }
 
   get value4(): Bytes {
-    return this._call.inputValues[4].value.toBytes()
+    return this._call.inputValues[4].value.toBytes();
   }
 }
 
 export class OnERC1155BatchReceivedCall__Outputs {
-  _call: OnERC1155BatchReceivedCall
+  _call: OnERC1155BatchReceivedCall;
 
   constructor(call: OnERC1155BatchReceivedCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): Bytes {
-    return this._call.outputValues[0].value.toBytes()
+    return this._call.outputValues[0].value.toBytes();
   }
 }
 
 export class OnERC1155ReceivedCall extends ethereum.Call {
   get inputs(): OnERC1155ReceivedCall__Inputs {
-    return new OnERC1155ReceivedCall__Inputs(this)
+    return new OnERC1155ReceivedCall__Inputs(this);
   }
 
   get outputs(): OnERC1155ReceivedCall__Outputs {
-    return new OnERC1155ReceivedCall__Outputs(this)
+    return new OnERC1155ReceivedCall__Outputs(this);
   }
 }
 
 export class OnERC1155ReceivedCall__Inputs {
-  _call: OnERC1155ReceivedCall
+  _call: OnERC1155ReceivedCall;
 
   constructor(call: OnERC1155ReceivedCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get value1(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get value2(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 
   get value3(): BigInt {
-    return this._call.inputValues[3].value.toBigInt()
+    return this._call.inputValues[3].value.toBigInt();
   }
 
   get value4(): Bytes {
-    return this._call.inputValues[4].value.toBytes()
+    return this._call.inputValues[4].value.toBytes();
   }
 }
 
 export class OnERC1155ReceivedCall__Outputs {
-  _call: OnERC1155ReceivedCall
+  _call: OnERC1155ReceivedCall;
 
   constructor(call: OnERC1155ReceivedCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): Bytes {
-    return this._call.outputValues[0].value.toBytes()
+    return this._call.outputValues[0].value.toBytes();
   }
 }
 
 export class ProvideCapitalCall extends ethereum.Call {
   get inputs(): ProvideCapitalCall__Inputs {
-    return new ProvideCapitalCall__Inputs(this)
+    return new ProvideCapitalCall__Inputs(this);
   }
 
   get outputs(): ProvideCapitalCall__Outputs {
-    return new ProvideCapitalCall__Outputs(this)
+    return new ProvideCapitalCall__Outputs(this);
   }
 }
 
 export class ProvideCapitalCall__Inputs {
-  _call: ProvideCapitalCall
+  _call: ProvideCapitalCall;
 
   constructor(call: ProvideCapitalCall) {
-    this._call = call
+    this._call = call;
   }
 
   get collateralAmount(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get lpTokenMinimum(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class ProvideCapitalCall__Outputs {
-  _call: ProvideCapitalCall
+  _call: ProvideCapitalCall;
 
   constructor(call: ProvideCapitalCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceOwnershipCall extends ethereum.Call {
   get inputs(): RenounceOwnershipCall__Inputs {
-    return new RenounceOwnershipCall__Inputs(this)
+    return new RenounceOwnershipCall__Inputs(this);
   }
 
   get outputs(): RenounceOwnershipCall__Outputs {
-    return new RenounceOwnershipCall__Outputs(this)
+    return new RenounceOwnershipCall__Outputs(this);
   }
 }
 
 export class RenounceOwnershipCall__Inputs {
-  _call: RenounceOwnershipCall
+  _call: RenounceOwnershipCall;
 
   constructor(call: RenounceOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceOwnershipCall__Outputs {
-  _call: RenounceOwnershipCall
+  _call: RenounceOwnershipCall;
 
   constructor(call: RenounceOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class SetVolatilityFactorCall extends ethereum.Call {
   get inputs(): SetVolatilityFactorCall__Inputs {
-    return new SetVolatilityFactorCall__Inputs(this)
+    return new SetVolatilityFactorCall__Inputs(this);
   }
 
   get outputs(): SetVolatilityFactorCall__Outputs {
-    return new SetVolatilityFactorCall__Outputs(this)
+    return new SetVolatilityFactorCall__Outputs(this);
   }
 }
 
 export class SetVolatilityFactorCall__Inputs {
-  _call: SetVolatilityFactorCall
+  _call: SetVolatilityFactorCall;
 
   constructor(call: SetVolatilityFactorCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _volatilityFactor(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 }
 
 export class SetVolatilityFactorCall__Outputs {
-  _call: SetVolatilityFactorCall
+  _call: SetVolatilityFactorCall;
 
   constructor(call: SetVolatilityFactorCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class TransferOwnershipCall extends ethereum.Call {
   get inputs(): TransferOwnershipCall__Inputs {
-    return new TransferOwnershipCall__Inputs(this)
+    return new TransferOwnershipCall__Inputs(this);
   }
 
   get outputs(): TransferOwnershipCall__Outputs {
-    return new TransferOwnershipCall__Outputs(this)
+    return new TransferOwnershipCall__Outputs(this);
   }
 }
 
 export class TransferOwnershipCall__Inputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 
   get newOwner(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class TransferOwnershipCall__Outputs {
-  _call: TransferOwnershipCall
+  _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class UpdateImplementationCall extends ethereum.Call {
   get inputs(): UpdateImplementationCall__Inputs {
-    return new UpdateImplementationCall__Inputs(this)
+    return new UpdateImplementationCall__Inputs(this);
   }
 
   get outputs(): UpdateImplementationCall__Outputs {
-    return new UpdateImplementationCall__Outputs(this)
+    return new UpdateImplementationCall__Outputs(this);
   }
 }
 
 export class UpdateImplementationCall__Inputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _newImplementation(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 }
 
 export class UpdateImplementationCall__Outputs {
-  _call: UpdateImplementationCall
+  _call: UpdateImplementationCall;
 
   constructor(call: UpdateImplementationCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class WTokenSellCall extends ethereum.Call {
   get inputs(): WTokenSellCall__Inputs {
-    return new WTokenSellCall__Inputs(this)
+    return new WTokenSellCall__Inputs(this);
   }
 
   get outputs(): WTokenSellCall__Outputs {
-    return new WTokenSellCall__Outputs(this)
+    return new WTokenSellCall__Outputs(this);
   }
 }
 
 export class WTokenSellCall__Inputs {
-  _call: WTokenSellCall
+  _call: WTokenSellCall;
 
   constructor(call: WTokenSellCall) {
-    this._call = call
+    this._call = call;
   }
 
   get seriesId(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get wTokenAmount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 
   get collateralMinimum(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 }
 
 export class WTokenSellCall__Outputs {
-  _call: WTokenSellCall
+  _call: WTokenSellCall;
 
   constructor(call: WTokenSellCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): BigInt {
-    return this._call.outputValues[0].value.toBigInt()
+    return this._call.outputValues[0].value.toBigInt();
   }
 }
 
 export class WithdrawCapitalCall extends ethereum.Call {
   get inputs(): WithdrawCapitalCall__Inputs {
-    return new WithdrawCapitalCall__Inputs(this)
+    return new WithdrawCapitalCall__Inputs(this);
   }
 
   get outputs(): WithdrawCapitalCall__Outputs {
-    return new WithdrawCapitalCall__Outputs(this)
+    return new WithdrawCapitalCall__Outputs(this);
   }
 }
 
 export class WithdrawCapitalCall__Inputs {
-  _call: WithdrawCapitalCall
+  _call: WithdrawCapitalCall;
 
   constructor(call: WithdrawCapitalCall) {
-    this._call = call
+    this._call = call;
   }
 
   get lpTokenAmount(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 
   get sellTokens(): boolean {
-    return this._call.inputValues[1].value.toBoolean()
+    return this._call.inputValues[1].value.toBoolean();
   }
 
   get collateralMinimum(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 }
 
 export class WithdrawCapitalCall__Outputs {
-  _call: WithdrawCapitalCall
+  _call: WithdrawCapitalCall;
 
   constructor(call: WithdrawCapitalCall) {
-    this._call = call
+    this._call = call;
   }
 }

--- a/subgraph/generated/templates/Amm/SimpleToken.ts
+++ b/subgraph/generated/templates/Amm/SimpleToken.ts
@@ -7,273 +7,273 @@ import {
   Entity,
   Bytes,
   Address,
-  BigInt,
-} from "@graphprotocol/graph-ts"
+  BigInt
+} from "@graphprotocol/graph-ts";
 
 export class Approval extends ethereum.Event {
   get params(): Approval__Params {
-    return new Approval__Params(this)
+    return new Approval__Params(this);
   }
 }
 
 export class Approval__Params {
-  _event: Approval
+  _event: Approval;
 
   constructor(event: Approval) {
-    this._event = event
+    this._event = event;
   }
 
   get owner(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get spender(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get value(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class RoleAdminChanged extends ethereum.Event {
   get params(): RoleAdminChanged__Params {
-    return new RoleAdminChanged__Params(this)
+    return new RoleAdminChanged__Params(this);
   }
 }
 
 export class RoleAdminChanged__Params {
-  _event: RoleAdminChanged
+  _event: RoleAdminChanged;
 
   constructor(event: RoleAdminChanged) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get previousAdminRole(): Bytes {
-    return this._event.parameters[1].value.toBytes()
+    return this._event.parameters[1].value.toBytes();
   }
 
   get newAdminRole(): Bytes {
-    return this._event.parameters[2].value.toBytes()
+    return this._event.parameters[2].value.toBytes();
   }
 }
 
 export class RoleGranted extends ethereum.Event {
   get params(): RoleGranted__Params {
-    return new RoleGranted__Params(this)
+    return new RoleGranted__Params(this);
   }
 }
 
 export class RoleGranted__Params {
-  _event: RoleGranted
+  _event: RoleGranted;
 
   constructor(event: RoleGranted) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class RoleRevoked extends ethereum.Event {
   get params(): RoleRevoked__Params {
-    return new RoleRevoked__Params(this)
+    return new RoleRevoked__Params(this);
   }
 }
 
 export class RoleRevoked__Params {
-  _event: RoleRevoked
+  _event: RoleRevoked;
 
   constructor(event: RoleRevoked) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class Transfer extends ethereum.Event {
   get params(): Transfer__Params {
-    return new Transfer__Params(this)
+    return new Transfer__Params(this);
   }
 }
 
 export class Transfer__Params {
-  _event: Transfer
+  _event: Transfer;
 
   constructor(event: Transfer) {
-    this._event = event
+    this._event = event;
   }
 
   get from(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get to(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get value(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class SimpleToken extends ethereum.SmartContract {
   static bind(address: Address): SimpleToken {
-    return new SimpleToken("SimpleToken", address)
+    return new SimpleToken("SimpleToken", address);
   }
 
   BURNER_ROLE(): Bytes {
-    let result = super.call("BURNER_ROLE", "BURNER_ROLE():(bytes32)", [])
+    let result = super.call("BURNER_ROLE", "BURNER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_BURNER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("BURNER_ROLE", "BURNER_ROLE():(bytes32)", [])
+    let result = super.tryCall("BURNER_ROLE", "BURNER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   DEFAULT_ADMIN_ROLE(): Bytes {
     let result = super.call(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_DEFAULT_ADMIN_ROLE(): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   MINTER_ROLE(): Bytes {
-    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_MINTER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   allowance(owner: Address, spender: Address): BigInt {
     let result = super.call(
       "allowance",
       "allowance(address,address):(uint256)",
-      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)],
-    )
+      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_allowance(owner: Address, spender: Address): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "allowance",
       "allowance(address,address):(uint256)",
-      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)],
-    )
+      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   approve(spender: Address, amount: BigInt): boolean {
     let result = super.call("approve", "approve(address,uint256):(bool)", [
       ethereum.Value.fromAddress(spender),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_approve(spender: Address, amount: BigInt): ethereum.CallResult<boolean> {
     let result = super.tryCall("approve", "approve(address,uint256):(bool)", [
       ethereum.Value.fromAddress(spender),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   balanceOf(account: Address): BigInt {
     let result = super.call("balanceOf", "balanceOf(address):(uint256)", [
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_balanceOf(account: Address): ethereum.CallResult<BigInt> {
     let result = super.tryCall("balanceOf", "balanceOf(address):(uint256)", [
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   decimals(): i32 {
-    let result = super.call("decimals", "decimals():(uint8)", [])
+    let result = super.call("decimals", "decimals():(uint8)", []);
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_decimals(): ethereum.CallResult<i32> {
-    let result = super.tryCall("decimals", "decimals():(uint8)", [])
+    let result = super.tryCall("decimals", "decimals():(uint8)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   decreaseAllowance(spender: Address, subtractedValue: BigInt): boolean {
@@ -282,72 +282,72 @@ export class SimpleToken extends ethereum.SmartContract {
       "decreaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(subtractedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(subtractedValue)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_decreaseAllowance(
     spender: Address,
-    subtractedValue: BigInt,
+    subtractedValue: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "decreaseAllowance",
       "decreaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(subtractedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(subtractedValue)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   getRoleAdmin(role: Bytes): Bytes {
     let result = super.call("getRoleAdmin", "getRoleAdmin(bytes32):(bytes32)", [
-      ethereum.Value.fromFixedBytes(role),
-    ])
+      ethereum.Value.fromFixedBytes(role)
+    ]);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_getRoleAdmin(role: Bytes): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "getRoleAdmin",
       "getRoleAdmin(bytes32):(bytes32)",
-      [ethereum.Value.fromFixedBytes(role)],
-    )
+      [ethereum.Value.fromFixedBytes(role)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   hasRole(role: Bytes, account: Address): boolean {
     let result = super.call("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_hasRole(role: Bytes, account: Address): ethereum.CallResult<boolean> {
     let result = super.tryCall("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   increaseAllowance(spender: Address, addedValue: BigInt): boolean {
@@ -356,122 +356,122 @@ export class SimpleToken extends ethereum.SmartContract {
       "increaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(addedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(addedValue)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_increaseAllowance(
     spender: Address,
-    addedValue: BigInt,
+    addedValue: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "increaseAllowance",
       "increaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(addedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(addedValue)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   name(): string {
-    let result = super.call("name", "name():(string)", [])
+    let result = super.call("name", "name():(string)", []);
 
-    return result[0].toString()
+    return result[0].toString();
   }
 
   try_name(): ethereum.CallResult<string> {
-    let result = super.tryCall("name", "name():(string)", [])
+    let result = super.tryCall("name", "name():(string)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toString())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toString());
   }
 
   supportsInterface(interfaceId: Bytes): boolean {
     let result = super.call(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_supportsInterface(interfaceId: Bytes): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   symbol(): string {
-    let result = super.call("symbol", "symbol():(string)", [])
+    let result = super.call("symbol", "symbol():(string)", []);
 
-    return result[0].toString()
+    return result[0].toString();
   }
 
   try_symbol(): ethereum.CallResult<string> {
-    let result = super.tryCall("symbol", "symbol():(string)", [])
+    let result = super.tryCall("symbol", "symbol():(string)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toString())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toString());
   }
 
   totalSupply(): BigInt {
-    let result = super.call("totalSupply", "totalSupply():(uint256)", [])
+    let result = super.call("totalSupply", "totalSupply():(uint256)", []);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_totalSupply(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall("totalSupply", "totalSupply():(uint256)", [])
+    let result = super.tryCall("totalSupply", "totalSupply():(uint256)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   transfer(recipient: Address, amount: BigInt): boolean {
     let result = super.call("transfer", "transfer(address,uint256):(bool)", [
       ethereum.Value.fromAddress(recipient),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_transfer(
     recipient: Address,
-    amount: BigInt,
+    amount: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall("transfer", "transfer(address,uint256):(bool)", [
       ethereum.Value.fromAddress(recipient),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   transferFrom(sender: Address, recipient: Address, amount: BigInt): boolean {
@@ -481,17 +481,17 @@ export class SimpleToken extends ethereum.SmartContract {
       [
         ethereum.Value.fromAddress(sender),
         ethereum.Value.fromAddress(recipient),
-        ethereum.Value.fromUnsignedBigInt(amount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(amount)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_transferFrom(
     sender: Address,
     recipient: Address,
-    amount: BigInt,
+    amount: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "transferFrom",
@@ -499,479 +499,479 @@ export class SimpleToken extends ethereum.SmartContract {
       [
         ethereum.Value.fromAddress(sender),
         ethereum.Value.fromAddress(recipient),
-        ethereum.Value.fromUnsignedBigInt(amount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(amount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 }
 
 export class ApproveCall extends ethereum.Call {
   get inputs(): ApproveCall__Inputs {
-    return new ApproveCall__Inputs(this)
+    return new ApproveCall__Inputs(this);
   }
 
   get outputs(): ApproveCall__Outputs {
-    return new ApproveCall__Outputs(this)
+    return new ApproveCall__Outputs(this);
   }
 }
 
 export class ApproveCall__Inputs {
-  _call: ApproveCall
+  _call: ApproveCall;
 
   constructor(call: ApproveCall) {
-    this._call = call
+    this._call = call;
   }
 
   get spender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class ApproveCall__Outputs {
-  _call: ApproveCall
+  _call: ApproveCall;
 
   constructor(call: ApproveCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class BurnCall extends ethereum.Call {
   get inputs(): BurnCall__Inputs {
-    return new BurnCall__Inputs(this)
+    return new BurnCall__Inputs(this);
   }
 
   get outputs(): BurnCall__Outputs {
-    return new BurnCall__Outputs(this)
+    return new BurnCall__Outputs(this);
   }
 }
 
 export class BurnCall__Inputs {
-  _call: BurnCall
+  _call: BurnCall;
 
   constructor(call: BurnCall) {
-    this._call = call
+    this._call = call;
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 }
 
 export class BurnCall__Outputs {
-  _call: BurnCall
+  _call: BurnCall;
 
   constructor(call: BurnCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class Burn1Call extends ethereum.Call {
   get inputs(): Burn1Call__Inputs {
-    return new Burn1Call__Inputs(this)
+    return new Burn1Call__Inputs(this);
   }
 
   get outputs(): Burn1Call__Outputs {
-    return new Burn1Call__Outputs(this)
+    return new Burn1Call__Outputs(this);
   }
 }
 
 export class Burn1Call__Inputs {
-  _call: Burn1Call
+  _call: Burn1Call;
 
   constructor(call: Burn1Call) {
-    this._call = call
+    this._call = call;
   }
 
   get account(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class Burn1Call__Outputs {
-  _call: Burn1Call
+  _call: Burn1Call;
 
   constructor(call: Burn1Call) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class BurnFromCall extends ethereum.Call {
   get inputs(): BurnFromCall__Inputs {
-    return new BurnFromCall__Inputs(this)
+    return new BurnFromCall__Inputs(this);
   }
 
   get outputs(): BurnFromCall__Outputs {
-    return new BurnFromCall__Outputs(this)
+    return new BurnFromCall__Outputs(this);
   }
 }
 
 export class BurnFromCall__Inputs {
-  _call: BurnFromCall
+  _call: BurnFromCall;
 
   constructor(call: BurnFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get account(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class BurnFromCall__Outputs {
-  _call: BurnFromCall
+  _call: BurnFromCall;
 
   constructor(call: BurnFromCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class DecreaseAllowanceCall extends ethereum.Call {
   get inputs(): DecreaseAllowanceCall__Inputs {
-    return new DecreaseAllowanceCall__Inputs(this)
+    return new DecreaseAllowanceCall__Inputs(this);
   }
 
   get outputs(): DecreaseAllowanceCall__Outputs {
-    return new DecreaseAllowanceCall__Outputs(this)
+    return new DecreaseAllowanceCall__Outputs(this);
   }
 }
 
 export class DecreaseAllowanceCall__Inputs {
-  _call: DecreaseAllowanceCall
+  _call: DecreaseAllowanceCall;
 
   constructor(call: DecreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get spender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get subtractedValue(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class DecreaseAllowanceCall__Outputs {
-  _call: DecreaseAllowanceCall
+  _call: DecreaseAllowanceCall;
 
   constructor(call: DecreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class GrantRoleCall extends ethereum.Call {
   get inputs(): GrantRoleCall__Inputs {
-    return new GrantRoleCall__Inputs(this)
+    return new GrantRoleCall__Inputs(this);
   }
 
   get outputs(): GrantRoleCall__Outputs {
-    return new GrantRoleCall__Outputs(this)
+    return new GrantRoleCall__Outputs(this);
   }
 }
 
 export class GrantRoleCall__Inputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class GrantRoleCall__Outputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class IncreaseAllowanceCall extends ethereum.Call {
   get inputs(): IncreaseAllowanceCall__Inputs {
-    return new IncreaseAllowanceCall__Inputs(this)
+    return new IncreaseAllowanceCall__Inputs(this);
   }
 
   get outputs(): IncreaseAllowanceCall__Outputs {
-    return new IncreaseAllowanceCall__Outputs(this)
+    return new IncreaseAllowanceCall__Outputs(this);
   }
 }
 
 export class IncreaseAllowanceCall__Inputs {
-  _call: IncreaseAllowanceCall
+  _call: IncreaseAllowanceCall;
 
   constructor(call: IncreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get spender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get addedValue(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class IncreaseAllowanceCall__Outputs {
-  _call: IncreaseAllowanceCall
+  _call: IncreaseAllowanceCall;
 
   constructor(call: IncreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class InitializeCall extends ethereum.Call {
   get inputs(): InitializeCall__Inputs {
-    return new InitializeCall__Inputs(this)
+    return new InitializeCall__Inputs(this);
   }
 
   get outputs(): InitializeCall__Outputs {
-    return new InitializeCall__Outputs(this)
+    return new InitializeCall__Outputs(this);
   }
 }
 
 export class InitializeCall__Inputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _name(): string {
-    return this._call.inputValues[0].value.toString()
+    return this._call.inputValues[0].value.toString();
   }
 
   get _symbol(): string {
-    return this._call.inputValues[1].value.toString()
+    return this._call.inputValues[1].value.toString();
   }
 
   get _decimals(): i32 {
-    return this._call.inputValues[2].value.toI32()
+    return this._call.inputValues[2].value.toI32();
   }
 }
 
 export class InitializeCall__Outputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class MintCall extends ethereum.Call {
   get inputs(): MintCall__Inputs {
-    return new MintCall__Inputs(this)
+    return new MintCall__Inputs(this);
   }
 
   get outputs(): MintCall__Outputs {
-    return new MintCall__Outputs(this)
+    return new MintCall__Outputs(this);
   }
 }
 
 export class MintCall__Inputs {
-  _call: MintCall
+  _call: MintCall;
 
   constructor(call: MintCall) {
-    this._call = call
+    this._call = call;
   }
 
   get to(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class MintCall__Outputs {
-  _call: MintCall
+  _call: MintCall;
 
   constructor(call: MintCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceRoleCall extends ethereum.Call {
   get inputs(): RenounceRoleCall__Inputs {
-    return new RenounceRoleCall__Inputs(this)
+    return new RenounceRoleCall__Inputs(this);
   }
 
   get outputs(): RenounceRoleCall__Outputs {
-    return new RenounceRoleCall__Outputs(this)
+    return new RenounceRoleCall__Outputs(this);
   }
 }
 
 export class RenounceRoleCall__Inputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RenounceRoleCall__Outputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RevokeRoleCall extends ethereum.Call {
   get inputs(): RevokeRoleCall__Inputs {
-    return new RevokeRoleCall__Inputs(this)
+    return new RevokeRoleCall__Inputs(this);
   }
 
   get outputs(): RevokeRoleCall__Outputs {
-    return new RevokeRoleCall__Outputs(this)
+    return new RevokeRoleCall__Outputs(this);
   }
 }
 
 export class RevokeRoleCall__Inputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RevokeRoleCall__Outputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class TransferCall extends ethereum.Call {
   get inputs(): TransferCall__Inputs {
-    return new TransferCall__Inputs(this)
+    return new TransferCall__Inputs(this);
   }
 
   get outputs(): TransferCall__Outputs {
-    return new TransferCall__Outputs(this)
+    return new TransferCall__Outputs(this);
   }
 }
 
 export class TransferCall__Inputs {
-  _call: TransferCall
+  _call: TransferCall;
 
   constructor(call: TransferCall) {
-    this._call = call
+    this._call = call;
   }
 
   get recipient(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class TransferCall__Outputs {
-  _call: TransferCall
+  _call: TransferCall;
 
   constructor(call: TransferCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class TransferFromCall extends ethereum.Call {
   get inputs(): TransferFromCall__Inputs {
-    return new TransferFromCall__Inputs(this)
+    return new TransferFromCall__Inputs(this);
   }
 
   get outputs(): TransferFromCall__Outputs {
-    return new TransferFromCall__Outputs(this)
+    return new TransferFromCall__Outputs(this);
   }
 }
 
 export class TransferFromCall__Inputs {
-  _call: TransferFromCall
+  _call: TransferFromCall;
 
   constructor(call: TransferFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get sender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get recipient(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 }
 
 export class TransferFromCall__Outputs {
-  _call: TransferFromCall
+  _call: TransferFromCall;
 
   constructor(call: TransferFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }

--- a/subgraph/generated/templates/SimpleToken/SimpleToken.ts
+++ b/subgraph/generated/templates/SimpleToken/SimpleToken.ts
@@ -7,273 +7,273 @@ import {
   Entity,
   Bytes,
   Address,
-  BigInt,
-} from "@graphprotocol/graph-ts"
+  BigInt
+} from "@graphprotocol/graph-ts";
 
 export class Approval extends ethereum.Event {
   get params(): Approval__Params {
-    return new Approval__Params(this)
+    return new Approval__Params(this);
   }
 }
 
 export class Approval__Params {
-  _event: Approval
+  _event: Approval;
 
   constructor(event: Approval) {
-    this._event = event
+    this._event = event;
   }
 
   get owner(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get spender(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get value(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class RoleAdminChanged extends ethereum.Event {
   get params(): RoleAdminChanged__Params {
-    return new RoleAdminChanged__Params(this)
+    return new RoleAdminChanged__Params(this);
   }
 }
 
 export class RoleAdminChanged__Params {
-  _event: RoleAdminChanged
+  _event: RoleAdminChanged;
 
   constructor(event: RoleAdminChanged) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get previousAdminRole(): Bytes {
-    return this._event.parameters[1].value.toBytes()
+    return this._event.parameters[1].value.toBytes();
   }
 
   get newAdminRole(): Bytes {
-    return this._event.parameters[2].value.toBytes()
+    return this._event.parameters[2].value.toBytes();
   }
 }
 
 export class RoleGranted extends ethereum.Event {
   get params(): RoleGranted__Params {
-    return new RoleGranted__Params(this)
+    return new RoleGranted__Params(this);
   }
 }
 
 export class RoleGranted__Params {
-  _event: RoleGranted
+  _event: RoleGranted;
 
   constructor(event: RoleGranted) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class RoleRevoked extends ethereum.Event {
   get params(): RoleRevoked__Params {
-    return new RoleRevoked__Params(this)
+    return new RoleRevoked__Params(this);
   }
 }
 
 export class RoleRevoked__Params {
-  _event: RoleRevoked
+  _event: RoleRevoked;
 
   constructor(event: RoleRevoked) {
-    this._event = event
+    this._event = event;
   }
 
   get role(): Bytes {
-    return this._event.parameters[0].value.toBytes()
+    return this._event.parameters[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get sender(): Address {
-    return this._event.parameters[2].value.toAddress()
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
 export class Transfer extends ethereum.Event {
   get params(): Transfer__Params {
-    return new Transfer__Params(this)
+    return new Transfer__Params(this);
   }
 }
 
 export class Transfer__Params {
-  _event: Transfer
+  _event: Transfer;
 
   constructor(event: Transfer) {
-    this._event = event
+    this._event = event;
   }
 
   get from(): Address {
-    return this._event.parameters[0].value.toAddress()
+    return this._event.parameters[0].value.toAddress();
   }
 
   get to(): Address {
-    return this._event.parameters[1].value.toAddress()
+    return this._event.parameters[1].value.toAddress();
   }
 
   get value(): BigInt {
-    return this._event.parameters[2].value.toBigInt()
+    return this._event.parameters[2].value.toBigInt();
   }
 }
 
 export class SimpleToken extends ethereum.SmartContract {
   static bind(address: Address): SimpleToken {
-    return new SimpleToken("SimpleToken", address)
+    return new SimpleToken("SimpleToken", address);
   }
 
   BURNER_ROLE(): Bytes {
-    let result = super.call("BURNER_ROLE", "BURNER_ROLE():(bytes32)", [])
+    let result = super.call("BURNER_ROLE", "BURNER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_BURNER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("BURNER_ROLE", "BURNER_ROLE():(bytes32)", [])
+    let result = super.tryCall("BURNER_ROLE", "BURNER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   DEFAULT_ADMIN_ROLE(): Bytes {
     let result = super.call(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_DEFAULT_ADMIN_ROLE(): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "DEFAULT_ADMIN_ROLE",
       "DEFAULT_ADMIN_ROLE():(bytes32)",
-      [],
-    )
+      []
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   MINTER_ROLE(): Bytes {
-    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.call("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_MINTER_ROLE(): ethereum.CallResult<Bytes> {
-    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", [])
+    let result = super.tryCall("MINTER_ROLE", "MINTER_ROLE():(bytes32)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   allowance(owner: Address, spender: Address): BigInt {
     let result = super.call(
       "allowance",
       "allowance(address,address):(uint256)",
-      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)],
-    )
+      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)]
+    );
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_allowance(owner: Address, spender: Address): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
       "allowance",
       "allowance(address,address):(uint256)",
-      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)],
-    )
+      [ethereum.Value.fromAddress(owner), ethereum.Value.fromAddress(spender)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   approve(spender: Address, amount: BigInt): boolean {
     let result = super.call("approve", "approve(address,uint256):(bool)", [
       ethereum.Value.fromAddress(spender),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_approve(spender: Address, amount: BigInt): ethereum.CallResult<boolean> {
     let result = super.tryCall("approve", "approve(address,uint256):(bool)", [
       ethereum.Value.fromAddress(spender),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   balanceOf(account: Address): BigInt {
     let result = super.call("balanceOf", "balanceOf(address):(uint256)", [
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_balanceOf(account: Address): ethereum.CallResult<BigInt> {
     let result = super.tryCall("balanceOf", "balanceOf(address):(uint256)", [
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   decimals(): i32 {
-    let result = super.call("decimals", "decimals():(uint8)", [])
+    let result = super.call("decimals", "decimals():(uint8)", []);
 
-    return result[0].toI32()
+    return result[0].toI32();
   }
 
   try_decimals(): ethereum.CallResult<i32> {
-    let result = super.tryCall("decimals", "decimals():(uint8)", [])
+    let result = super.tryCall("decimals", "decimals():(uint8)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toI32())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   decreaseAllowance(spender: Address, subtractedValue: BigInt): boolean {
@@ -282,72 +282,72 @@ export class SimpleToken extends ethereum.SmartContract {
       "decreaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(subtractedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(subtractedValue)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_decreaseAllowance(
     spender: Address,
-    subtractedValue: BigInt,
+    subtractedValue: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "decreaseAllowance",
       "decreaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(subtractedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(subtractedValue)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   getRoleAdmin(role: Bytes): Bytes {
     let result = super.call("getRoleAdmin", "getRoleAdmin(bytes32):(bytes32)", [
-      ethereum.Value.fromFixedBytes(role),
-    ])
+      ethereum.Value.fromFixedBytes(role)
+    ]);
 
-    return result[0].toBytes()
+    return result[0].toBytes();
   }
 
   try_getRoleAdmin(role: Bytes): ethereum.CallResult<Bytes> {
     let result = super.tryCall(
       "getRoleAdmin",
       "getRoleAdmin(bytes32):(bytes32)",
-      [ethereum.Value.fromFixedBytes(role)],
-    )
+      [ethereum.Value.fromFixedBytes(role)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBytes())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBytes());
   }
 
   hasRole(role: Bytes, account: Address): boolean {
     let result = super.call("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_hasRole(role: Bytes, account: Address): ethereum.CallResult<boolean> {
     let result = super.tryCall("hasRole", "hasRole(bytes32,address):(bool)", [
       ethereum.Value.fromFixedBytes(role),
-      ethereum.Value.fromAddress(account),
-    ])
+      ethereum.Value.fromAddress(account)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   increaseAllowance(spender: Address, addedValue: BigInt): boolean {
@@ -356,122 +356,122 @@ export class SimpleToken extends ethereum.SmartContract {
       "increaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(addedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(addedValue)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_increaseAllowance(
     spender: Address,
-    addedValue: BigInt,
+    addedValue: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "increaseAllowance",
       "increaseAllowance(address,uint256):(bool)",
       [
         ethereum.Value.fromAddress(spender),
-        ethereum.Value.fromUnsignedBigInt(addedValue),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(addedValue)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   name(): string {
-    let result = super.call("name", "name():(string)", [])
+    let result = super.call("name", "name():(string)", []);
 
-    return result[0].toString()
+    return result[0].toString();
   }
 
   try_name(): ethereum.CallResult<string> {
-    let result = super.tryCall("name", "name():(string)", [])
+    let result = super.tryCall("name", "name():(string)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toString())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toString());
   }
 
   supportsInterface(interfaceId: Bytes): boolean {
     let result = super.call(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_supportsInterface(interfaceId: Bytes): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "supportsInterface",
       "supportsInterface(bytes4):(bool)",
-      [ethereum.Value.fromFixedBytes(interfaceId)],
-    )
+      [ethereum.Value.fromFixedBytes(interfaceId)]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   symbol(): string {
-    let result = super.call("symbol", "symbol():(string)", [])
+    let result = super.call("symbol", "symbol():(string)", []);
 
-    return result[0].toString()
+    return result[0].toString();
   }
 
   try_symbol(): ethereum.CallResult<string> {
-    let result = super.tryCall("symbol", "symbol():(string)", [])
+    let result = super.tryCall("symbol", "symbol():(string)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toString())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toString());
   }
 
   totalSupply(): BigInt {
-    let result = super.call("totalSupply", "totalSupply():(uint256)", [])
+    let result = super.call("totalSupply", "totalSupply():(uint256)", []);
 
-    return result[0].toBigInt()
+    return result[0].toBigInt();
   }
 
   try_totalSupply(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall("totalSupply", "totalSupply():(uint256)", [])
+    let result = super.tryCall("totalSupply", "totalSupply():(uint256)", []);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBigInt())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   transfer(recipient: Address, amount: BigInt): boolean {
     let result = super.call("transfer", "transfer(address,uint256):(bool)", [
       ethereum.Value.fromAddress(recipient),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_transfer(
     recipient: Address,
-    amount: BigInt,
+    amount: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall("transfer", "transfer(address,uint256):(bool)", [
       ethereum.Value.fromAddress(recipient),
-      ethereum.Value.fromUnsignedBigInt(amount),
-    ])
+      ethereum.Value.fromUnsignedBigInt(amount)
+    ]);
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   transferFrom(sender: Address, recipient: Address, amount: BigInt): boolean {
@@ -481,17 +481,17 @@ export class SimpleToken extends ethereum.SmartContract {
       [
         ethereum.Value.fromAddress(sender),
         ethereum.Value.fromAddress(recipient),
-        ethereum.Value.fromUnsignedBigInt(amount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(amount)
+      ]
+    );
 
-    return result[0].toBoolean()
+    return result[0].toBoolean();
   }
 
   try_transferFrom(
     sender: Address,
     recipient: Address,
-    amount: BigInt,
+    amount: BigInt
   ): ethereum.CallResult<boolean> {
     let result = super.tryCall(
       "transferFrom",
@@ -499,479 +499,479 @@ export class SimpleToken extends ethereum.SmartContract {
       [
         ethereum.Value.fromAddress(sender),
         ethereum.Value.fromAddress(recipient),
-        ethereum.Value.fromUnsignedBigInt(amount),
-      ],
-    )
+        ethereum.Value.fromUnsignedBigInt(amount)
+      ]
+    );
     if (result.reverted) {
-      return new ethereum.CallResult()
+      return new ethereum.CallResult();
     }
-    let value = result.value
-    return ethereum.CallResult.fromValue(value[0].toBoolean())
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 }
 
 export class ApproveCall extends ethereum.Call {
   get inputs(): ApproveCall__Inputs {
-    return new ApproveCall__Inputs(this)
+    return new ApproveCall__Inputs(this);
   }
 
   get outputs(): ApproveCall__Outputs {
-    return new ApproveCall__Outputs(this)
+    return new ApproveCall__Outputs(this);
   }
 }
 
 export class ApproveCall__Inputs {
-  _call: ApproveCall
+  _call: ApproveCall;
 
   constructor(call: ApproveCall) {
-    this._call = call
+    this._call = call;
   }
 
   get spender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class ApproveCall__Outputs {
-  _call: ApproveCall
+  _call: ApproveCall;
 
   constructor(call: ApproveCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class BurnCall extends ethereum.Call {
   get inputs(): BurnCall__Inputs {
-    return new BurnCall__Inputs(this)
+    return new BurnCall__Inputs(this);
   }
 
   get outputs(): BurnCall__Outputs {
-    return new BurnCall__Outputs(this)
+    return new BurnCall__Outputs(this);
   }
 }
 
 export class BurnCall__Inputs {
-  _call: BurnCall
+  _call: BurnCall;
 
   constructor(call: BurnCall) {
-    this._call = call
+    this._call = call;
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[0].value.toBigInt()
+    return this._call.inputValues[0].value.toBigInt();
   }
 }
 
 export class BurnCall__Outputs {
-  _call: BurnCall
+  _call: BurnCall;
 
   constructor(call: BurnCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class Burn1Call extends ethereum.Call {
   get inputs(): Burn1Call__Inputs {
-    return new Burn1Call__Inputs(this)
+    return new Burn1Call__Inputs(this);
   }
 
   get outputs(): Burn1Call__Outputs {
-    return new Burn1Call__Outputs(this)
+    return new Burn1Call__Outputs(this);
   }
 }
 
 export class Burn1Call__Inputs {
-  _call: Burn1Call
+  _call: Burn1Call;
 
   constructor(call: Burn1Call) {
-    this._call = call
+    this._call = call;
   }
 
   get account(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class Burn1Call__Outputs {
-  _call: Burn1Call
+  _call: Burn1Call;
 
   constructor(call: Burn1Call) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class BurnFromCall extends ethereum.Call {
   get inputs(): BurnFromCall__Inputs {
-    return new BurnFromCall__Inputs(this)
+    return new BurnFromCall__Inputs(this);
   }
 
   get outputs(): BurnFromCall__Outputs {
-    return new BurnFromCall__Outputs(this)
+    return new BurnFromCall__Outputs(this);
   }
 }
 
 export class BurnFromCall__Inputs {
-  _call: BurnFromCall
+  _call: BurnFromCall;
 
   constructor(call: BurnFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get account(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class BurnFromCall__Outputs {
-  _call: BurnFromCall
+  _call: BurnFromCall;
 
   constructor(call: BurnFromCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class DecreaseAllowanceCall extends ethereum.Call {
   get inputs(): DecreaseAllowanceCall__Inputs {
-    return new DecreaseAllowanceCall__Inputs(this)
+    return new DecreaseAllowanceCall__Inputs(this);
   }
 
   get outputs(): DecreaseAllowanceCall__Outputs {
-    return new DecreaseAllowanceCall__Outputs(this)
+    return new DecreaseAllowanceCall__Outputs(this);
   }
 }
 
 export class DecreaseAllowanceCall__Inputs {
-  _call: DecreaseAllowanceCall
+  _call: DecreaseAllowanceCall;
 
   constructor(call: DecreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get spender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get subtractedValue(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class DecreaseAllowanceCall__Outputs {
-  _call: DecreaseAllowanceCall
+  _call: DecreaseAllowanceCall;
 
   constructor(call: DecreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class GrantRoleCall extends ethereum.Call {
   get inputs(): GrantRoleCall__Inputs {
-    return new GrantRoleCall__Inputs(this)
+    return new GrantRoleCall__Inputs(this);
   }
 
   get outputs(): GrantRoleCall__Outputs {
-    return new GrantRoleCall__Outputs(this)
+    return new GrantRoleCall__Outputs(this);
   }
 }
 
 export class GrantRoleCall__Inputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class GrantRoleCall__Outputs {
-  _call: GrantRoleCall
+  _call: GrantRoleCall;
 
   constructor(call: GrantRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class IncreaseAllowanceCall extends ethereum.Call {
   get inputs(): IncreaseAllowanceCall__Inputs {
-    return new IncreaseAllowanceCall__Inputs(this)
+    return new IncreaseAllowanceCall__Inputs(this);
   }
 
   get outputs(): IncreaseAllowanceCall__Outputs {
-    return new IncreaseAllowanceCall__Outputs(this)
+    return new IncreaseAllowanceCall__Outputs(this);
   }
 }
 
 export class IncreaseAllowanceCall__Inputs {
-  _call: IncreaseAllowanceCall
+  _call: IncreaseAllowanceCall;
 
   constructor(call: IncreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get spender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get addedValue(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class IncreaseAllowanceCall__Outputs {
-  _call: IncreaseAllowanceCall
+  _call: IncreaseAllowanceCall;
 
   constructor(call: IncreaseAllowanceCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class InitializeCall extends ethereum.Call {
   get inputs(): InitializeCall__Inputs {
-    return new InitializeCall__Inputs(this)
+    return new InitializeCall__Inputs(this);
   }
 
   get outputs(): InitializeCall__Outputs {
-    return new InitializeCall__Outputs(this)
+    return new InitializeCall__Outputs(this);
   }
 }
 
 export class InitializeCall__Inputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 
   get _name(): string {
-    return this._call.inputValues[0].value.toString()
+    return this._call.inputValues[0].value.toString();
   }
 
   get _symbol(): string {
-    return this._call.inputValues[1].value.toString()
+    return this._call.inputValues[1].value.toString();
   }
 
   get _decimals(): i32 {
-    return this._call.inputValues[2].value.toI32()
+    return this._call.inputValues[2].value.toI32();
   }
 }
 
 export class InitializeCall__Outputs {
-  _call: InitializeCall
+  _call: InitializeCall;
 
   constructor(call: InitializeCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class MintCall extends ethereum.Call {
   get inputs(): MintCall__Inputs {
-    return new MintCall__Inputs(this)
+    return new MintCall__Inputs(this);
   }
 
   get outputs(): MintCall__Outputs {
-    return new MintCall__Outputs(this)
+    return new MintCall__Outputs(this);
   }
 }
 
 export class MintCall__Inputs {
-  _call: MintCall
+  _call: MintCall;
 
   constructor(call: MintCall) {
-    this._call = call
+    this._call = call;
   }
 
   get to(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class MintCall__Outputs {
-  _call: MintCall
+  _call: MintCall;
 
   constructor(call: MintCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RenounceRoleCall extends ethereum.Call {
   get inputs(): RenounceRoleCall__Inputs {
-    return new RenounceRoleCall__Inputs(this)
+    return new RenounceRoleCall__Inputs(this);
   }
 
   get outputs(): RenounceRoleCall__Outputs {
-    return new RenounceRoleCall__Outputs(this)
+    return new RenounceRoleCall__Outputs(this);
   }
 }
 
 export class RenounceRoleCall__Inputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RenounceRoleCall__Outputs {
-  _call: RenounceRoleCall
+  _call: RenounceRoleCall;
 
   constructor(call: RenounceRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class RevokeRoleCall extends ethereum.Call {
   get inputs(): RevokeRoleCall__Inputs {
-    return new RevokeRoleCall__Inputs(this)
+    return new RevokeRoleCall__Inputs(this);
   }
 
   get outputs(): RevokeRoleCall__Outputs {
-    return new RevokeRoleCall__Outputs(this)
+    return new RevokeRoleCall__Outputs(this);
   }
 }
 
 export class RevokeRoleCall__Inputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 
   get role(): Bytes {
-    return this._call.inputValues[0].value.toBytes()
+    return this._call.inputValues[0].value.toBytes();
   }
 
   get account(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 }
 
 export class RevokeRoleCall__Outputs {
-  _call: RevokeRoleCall
+  _call: RevokeRoleCall;
 
   constructor(call: RevokeRoleCall) {
-    this._call = call
+    this._call = call;
   }
 }
 
 export class TransferCall extends ethereum.Call {
   get inputs(): TransferCall__Inputs {
-    return new TransferCall__Inputs(this)
+    return new TransferCall__Inputs(this);
   }
 
   get outputs(): TransferCall__Outputs {
-    return new TransferCall__Outputs(this)
+    return new TransferCall__Outputs(this);
   }
 }
 
 export class TransferCall__Inputs {
-  _call: TransferCall
+  _call: TransferCall;
 
   constructor(call: TransferCall) {
-    this._call = call
+    this._call = call;
   }
 
   get recipient(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[1].value.toBigInt()
+    return this._call.inputValues[1].value.toBigInt();
   }
 }
 
 export class TransferCall__Outputs {
-  _call: TransferCall
+  _call: TransferCall;
 
   constructor(call: TransferCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }
 
 export class TransferFromCall extends ethereum.Call {
   get inputs(): TransferFromCall__Inputs {
-    return new TransferFromCall__Inputs(this)
+    return new TransferFromCall__Inputs(this);
   }
 
   get outputs(): TransferFromCall__Outputs {
-    return new TransferFromCall__Outputs(this)
+    return new TransferFromCall__Outputs(this);
   }
 }
 
 export class TransferFromCall__Inputs {
-  _call: TransferFromCall
+  _call: TransferFromCall;
 
   constructor(call: TransferFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get sender(): Address {
-    return this._call.inputValues[0].value.toAddress()
+    return this._call.inputValues[0].value.toAddress();
   }
 
   get recipient(): Address {
-    return this._call.inputValues[1].value.toAddress()
+    return this._call.inputValues[1].value.toAddress();
   }
 
   get amount(): BigInt {
-    return this._call.inputValues[2].value.toBigInt()
+    return this._call.inputValues[2].value.toBigInt();
   }
 }
 
 export class TransferFromCall__Outputs {
-  _call: TransferFromCall
+  _call: TransferFromCall;
 
   constructor(call: TransferFromCall) {
-    this._call = call
+    this._call = call;
   }
 
   get value0(): boolean {
-    return this._call.outputValues[0].value.toBoolean()
+    return this._call.outputValues[0].value.toBoolean();
   }
 }

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -517,6 +517,7 @@ type BTokenBought implements AmmTokenEvent @entity {
   block: BigInt!
   timestamp: BigInt!
   poolValueSnapshot: PoolValueSnapshot!
+  seriesId: Int!
 }
 type BTokenSold implements AmmTokenEvent @entity {
   id: ID!
@@ -528,6 +529,7 @@ type BTokenSold implements AmmTokenEvent @entity {
   block: BigInt!
   timestamp: BigInt!
   poolValueSnapshot: PoolValueSnapshot!
+  seriesId: Int!
 }
 type WTokenSold implements AmmTokenEvent @entity {
   id: ID!
@@ -539,6 +541,7 @@ type WTokenSold implements AmmTokenEvent @entity {
   block: BigInt!
   timestamp: BigInt!
   poolValueSnapshot: PoolValueSnapshot!
+  seriesId: Int!
 }
 
 #

--- a/subgraph/src/mappings/amm.ts
+++ b/subgraph/src/mappings/amm.ts
@@ -112,6 +112,7 @@ export function handleBTokensBought(event: BTokensBought): void {
   bTokenBought.block = event.block.number
   bTokenBought.timestamp = event.block.timestamp
   bTokenBought.poolValueSnapshot = poolValueSnapShot.id
+  bTokenBought.seriesId = event.params.seriesId.toI32()
 
   bTokenBought.save()
 }
@@ -130,6 +131,7 @@ export function handleBTokensSold(event: BTokensSold): void {
   bTokenSold.block = event.block.number
   bTokenSold.timestamp = event.block.timestamp
   bTokenSold.poolValueSnapshot = poolValueSnapShot.id
+  bTokenSold.seriesId = event.params.seriesId.toI32()
 
   bTokenSold.save()
 }
@@ -148,6 +150,7 @@ export function handleWTokensSold(event: WTokensSold): void {
   wTokenSold.block = event.block.number
   wTokenSold.timestamp = event.block.timestamp
   wTokenSold.poolValueSnapshot = poolValueSnapShot.id
+  wTokenSold.seriesId = event.params.seriesId.toI32()
 
   wTokenSold.save()
 }


### PR DESCRIPTION
We want to be able to query for a particular account's trade events (BTokenBought, BTokenSold, and WTokenSold) for a particular Series. Prior to this commit there was no way to query by SeriesId. Now, a client can compare the BTokenBought and BTokenSold events to see when there are any instances where a user profited by buying low and selling high.