### PR TITLE
Move the following 4 functions in MinterAmm over to AmmDataProvider in

### DIFF
--- a/contracts/amm/AmmDataProvider.sol
+++ b/contracts/amm/AmmDataProvider.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 pragma solidity 0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -5,21 +7,25 @@ import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "./IAmmDataProvider.sol";
 import "../token/ISimpleToken.sol";
 import "../series/ISeriesController.sol";
+import "../series/IPriceOracle.sol";
 import "../series/SeriesLibrary.sol";
 import "../libraries/Math.sol";
 
 contract AmmDataProvider is IAmmDataProvider {
     ISeriesController public seriesController;
     IERC1155 public erc1155Controller;
+    IPriceOracle public priceOracle;
 
     event AmmDataProviderCreated(
         ISeriesController seriesController,
-        IERC1155 erc1155Controller
+        IERC1155 erc1155Controller,
+        IPriceOracle priceOracle
     );
 
     constructor(
         ISeriesController _seriesController,
-        IERC1155 _erc1155Controller
+        IERC1155 _erc1155Controller,
+        IPriceOracle _priceOracle
     ) {
         require(
             address(_seriesController) != address(0x0),
@@ -29,11 +35,20 @@ contract AmmDataProvider is IAmmDataProvider {
             address(_erc1155Controller) != address(0x0),
             "AmmDataProvider: _erc1155Controller cannot be the 0x0 address"
         );
+        require(
+            address(_priceOracle) != address(0x0),
+            "AmmDataProvider: _priceOracle cannot be the 0x0 address"
+        );
 
         seriesController = _seriesController;
         erc1155Controller = _erc1155Controller;
+        priceOracle = _priceOracle;
 
-        emit AmmDataProviderCreated(_seriesController, _erc1155Controller);
+        emit AmmDataProviderCreated(
+            _seriesController,
+            _erc1155Controller,
+            _priceOracle
+        );
     }
 
     /// This function determines reserves of a bonding curve for a specific series.
@@ -134,7 +149,7 @@ contract AmmDataProvider is IAmmDataProvider {
         uint256 currentPrice,
         uint256 volatility,
         bool isPutOption
-    ) external pure override returns (uint256) {
+    ) public pure override returns (uint256) {
         uint256 intrinsic = 0;
         uint256 timeValue = 0;
 
@@ -232,7 +247,7 @@ contract AmmDataProvider is IAmmDataProvider {
         uint256 collateralTokenBalance,
         uint256 bTokenPrice,
         bool isBToken
-    ) external view override returns (uint256) {
+    ) public view override returns (uint256) {
         // Shortcut for 0 amount
         if (optionTokenAmount == 0) return 0;
 
@@ -261,5 +276,290 @@ contract AmmDataProvider is IAmmDataProvider {
             )) / 2;
 
         return collateralAmount;
+    }
+
+    /// @dev Calculate the collateral amount receivable by redeeming the given
+    /// Series' bTokens and wToken
+    /// @param seriesId The index of the Series
+    /// @param wTokenBalance The wToken balance for this Series owned by this AMM
+    /// @param bTokenBalance The bToken balance for this Series owned by this AMM
+    /// @return The total amount of collateral receivable by redeeming the Series' option tokens
+    function getRedeemableCollateral(
+        uint64 seriesId,
+        uint256 wTokenBalance,
+        uint256 bTokenBalance
+    ) private view returns (uint256) {
+        uint256 unredeemedCollateral = 0;
+        if (wTokenBalance > 0) {
+            (uint256 unclaimedCollateral, ) = seriesController.getClaimAmount(
+                seriesId,
+                wTokenBalance
+            );
+            unredeemedCollateral += unclaimedCollateral;
+        }
+        if (bTokenBalance > 0) {
+            (uint256 unexercisedCollateral, ) = seriesController
+                .getExerciseAmount(seriesId, bTokenBalance);
+            unredeemedCollateral += unexercisedCollateral;
+        }
+
+        return unredeemedCollateral;
+    }
+
+    /// @notice Calculate the amount of collateral the AMM would received if all of the
+    /// expired Series' wTokens and bTokens were to be redeemed for their underlying collateral
+    /// value
+    /// @return The amount of collateral token the AMM would receive if it were to exercise/claim
+    /// all expired bTokens/wTokens
+    function getCollateralValueOfAllExpiredOptionTokens(
+        uint64[] memory openSeries,
+        address ammAddress
+    ) public view override returns (uint256) {
+        uint256 unredeemedCollateral = 0;
+
+        for (uint256 i = 0; i < openSeries.length; i++) {
+            uint64 seriesId = openSeries[i];
+
+            if (
+                seriesController.state(seriesId) ==
+                ISeriesController.SeriesState.EXPIRED
+            ) {
+                uint256 bTokenIndex = SeriesLibrary.bTokenIndex(seriesId);
+                uint256 wTokenIndex = SeriesLibrary.wTokenIndex(seriesId);
+
+                // Get the pool's option token balances
+                uint256 bTokenBalance = erc1155Controller.balanceOf(
+                    ammAddress,
+                    bTokenIndex
+                );
+                uint256 wTokenBalance = erc1155Controller.balanceOf(
+                    ammAddress,
+                    wTokenIndex
+                );
+
+                // calculate the amount of collateral The AMM would receive by
+                // redeeming this Series' bTokens and wTokens
+                unredeemedCollateral += getRedeemableCollateral(
+                    seriesId,
+                    wTokenBalance,
+                    bTokenBalance
+                );
+            }
+        }
+
+        return unredeemedCollateral;
+    }
+
+    /// @notice Calculate sale value of pro-rata LP b/wTokens in units of collateral token
+    function getOptionTokensSaleValue(
+        uint256 lpTokenAmount,
+        uint256 lpTokenSupply,
+        uint64[] memory openSeries,
+        address ammAddress,
+        uint256 collateralTokenBalance,
+        uint256 impliedVolatility
+    ) external view override returns (uint256) {
+        if (lpTokenAmount == 0) return 0;
+        if (lpTokenSupply == 0) return 0;
+
+        // Calculate the amount of collateral receivable by redeeming all the expired option tokens
+        uint256 expiredOptionTokenCollateral = getCollateralValueOfAllExpiredOptionTokens(
+                openSeries,
+                ammAddress
+            );
+
+        // Calculate amount of collateral left in the pool to sell tokens to
+        uint256 totalCollateral = expiredOptionTokenCollateral +
+            collateralTokenBalance;
+
+        // Subtract pro-rata collateral amount to be withdrawn
+        totalCollateral =
+            (totalCollateral * (lpTokenSupply - lpTokenAmount)) /
+            lpTokenSupply;
+
+        // Given remaining collateral calculate how much all tokens can be sold for
+        uint256 collateralLeft = totalCollateral;
+        for (uint256 i = 0; i < openSeries.length; i++) {
+            uint64 seriesId = openSeries[i];
+
+            if (
+                seriesController.state(seriesId) ==
+                ISeriesController.SeriesState.OPEN
+            ) {
+                uint256 bTokenToSell = (erc1155Controller.balanceOf(
+                    ammAddress,
+                    SeriesLibrary.bTokenIndex(seriesId)
+                ) * lpTokenAmount) / lpTokenSupply;
+                uint256 wTokenToSell = (erc1155Controller.balanceOf(
+                    ammAddress,
+                    SeriesLibrary.wTokenIndex(seriesId)
+                ) * lpTokenAmount) / lpTokenSupply;
+
+                uint256 bTokenPrice = getPriceForExpiredSeries(
+                    seriesId,
+                    impliedVolatility
+                );
+
+                uint256 collateralAmountB = optionTokenGetCollateralOut(
+                    seriesId,
+                    ammAddress,
+                    bTokenToSell,
+                    collateralLeft,
+                    bTokenPrice,
+                    true
+                );
+                collateralLeft -= collateralAmountB;
+
+                uint256 collateralAmountW = optionTokenGetCollateralOut(
+                    seriesId,
+                    ammAddress,
+                    wTokenToSell,
+                    collateralLeft,
+                    bTokenPrice,
+                    false
+                );
+                collateralLeft -= collateralAmountW;
+            }
+        }
+
+        return totalCollateral - collateralLeft;
+    }
+
+    /// @notice Get the bToken price for given Series, in units of the collateral token
+    /// and normalized to 1e18. We use a normalization factor of 1e18 because we need
+    /// to represent fractional values, yet Solidity does not support floating point numerics.
+    /// @notice For example, if this is a WBTC Call option pool and so
+    /// the collateral token is WBTC, then a return value of 0.5e18 means X units of bToken
+    /// have a price of 0.5 * X units of WBTC. Another example; if this were a WBTC Put
+    /// option pool, and so the collateral token is USDC, then a return value of 0.1e18 means
+    /// X units of bToken have a price of 0.1 * X * strikePrice units of USDC.
+    /// @notice This value will always be between 0 and 1e18, so you can think of it as
+    /// representing the price as a fraction of 1 collateral token unit
+    /// @dev This function assumes that it will only be called on an OPEN Series; if the
+    /// Series is EXPIRED, then the expirationDate - block.timestamp will throw an underflow error
+    function getPriceForExpiredSeries(uint64 seriesId, uint256 volatilityFactor)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        ISeriesController.Series memory series = seriesController.series(
+            seriesId
+        );
+        uint256 underlyingPrice = IPriceOracle(priceOracle).getCurrentPrice(
+            seriesController.underlyingToken(seriesId),
+            seriesController.priceToken(seriesId)
+        );
+
+        return
+            getPriceForExpiredSeriesInternal(
+                series,
+                underlyingPrice,
+                volatilityFactor
+            );
+    }
+
+    function getPriceForExpiredSeriesInternal(
+        ISeriesController.Series memory series,
+        uint256 underlyingPrice,
+        uint256 volatilityFactor
+    ) private view returns (uint256) {
+        return
+            // Note! This function assumes the underlyingPrice is a valid series
+            // price in units of underlyingToken/priceToken. If the onchain price
+            // oracle's value were to drift from the true series price, then the bToken price
+            // we calculate here would also drift, and will result in undefined
+            // behavior for any functions which call getPriceForExpiredSeriesInternal
+            calcPrice(
+                series.expirationDate - block.timestamp,
+                series.strikePrice,
+                underlyingPrice,
+                volatilityFactor,
+                series.isPutOption
+            );
+    }
+
+    /// Get value of all assets in the pool in units of this AMM's collateralToken.
+    /// Can specify whether to include the value of expired unclaimed tokens
+    function getTotalPoolValue(
+        bool includeUnclaimed,
+        uint64[] memory openSeries,
+        uint256 collateralBalance,
+        address ammAddress,
+        uint256 impliedVolatility
+    ) external view override returns (uint256) {
+        // Note! This function assumes the underlyingPrice is a valid series
+        // price in units of underlyingToken/priceToken. If the onchain price
+        // oracle's value were to drift from the true series price, then the bToken price
+        // we calculate here would also drift, and will result in undefined
+        // behavior for any functions which call getTotalPoolValue
+        uint256 underlyingPrice;
+        if (openSeries.length > 0) {
+            // we assume the openSeries are all from the same AMM, and thus all its Series
+            // use the same underlying and price tokens, so we can arbitrarily choose the first
+            // when fetching the necessary token addresses
+            underlyingPrice = IPriceOracle(priceOracle).getCurrentPrice(
+                seriesController.underlyingToken(openSeries[0]),
+                seriesController.priceToken(openSeries[0])
+            );
+        }
+
+        // First, determine the value of all residual b/wTokens
+        uint256 activeTokensValue = 0;
+        uint256 expiredTokensValue = 0;
+        for (uint256 i = 0; i < openSeries.length; i++) {
+            uint64 seriesId = openSeries[i];
+            ISeriesController.Series memory series = seriesController.series(
+                seriesId
+            );
+
+            uint256 bTokenIndex = SeriesLibrary.bTokenIndex(seriesId);
+            uint256 wTokenIndex = SeriesLibrary.wTokenIndex(seriesId);
+
+            uint256 bTokenBalance = erc1155Controller.balanceOf(
+                ammAddress,
+                bTokenIndex
+            );
+            uint256 wTokenBalance = erc1155Controller.balanceOf(
+                ammAddress,
+                wTokenIndex
+            );
+
+            if (
+                seriesController.state(seriesId) ==
+                ISeriesController.SeriesState.OPEN
+            ) {
+                // value all active bTokens and wTokens at current prices
+                uint256 bPrice = getPriceForExpiredSeriesInternal(
+                    series,
+                    underlyingPrice,
+                    impliedVolatility
+                );
+                // wPrice = 1 - bPrice
+                uint256 wPrice = uint256(1e18) - bPrice;
+
+                uint256 tokensValueCollateral = seriesController
+                    .getCollateralPerOptionToken(
+                        seriesId,
+                        (bTokenBalance * bPrice + wTokenBalance * wPrice) / 1e18
+                    );
+
+                activeTokensValue += tokensValueCollateral;
+            } else if (
+                includeUnclaimed &&
+                seriesController.state(seriesId) ==
+                ISeriesController.SeriesState.EXPIRED
+            ) {
+                // Get collateral token locked in the series
+                expiredTokensValue += getRedeemableCollateral(
+                    seriesId,
+                    wTokenBalance,
+                    bTokenBalance
+                );
+            }
+        }
+
+        // Add value of OPEN Series, EXPIRED Series, and collateral token
+        return activeTokensValue + expiredTokensValue + collateralBalance;
     }
 }

--- a/contracts/amm/AmmDataProvider.sol
+++ b/contracts/amm/AmmDataProvider.sol
@@ -288,7 +288,7 @@ contract AmmDataProvider is IAmmDataProvider {
         uint64 seriesId,
         uint256 wTokenBalance,
         uint256 bTokenBalance
-    ) private view returns (uint256) {
+    ) public view override returns (uint256) {
         uint256 unredeemedCollateral = 0;
         if (wTokenBalance > 0) {
             (uint256 unclaimedCollateral, ) = seriesController.getClaimAmount(

--- a/contracts/amm/IAmmDataProvider.sol
+++ b/contracts/amm/IAmmDataProvider.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 pragma solidity 0.8.0;
 
 interface IAmmDataProvider {
@@ -31,5 +33,32 @@ interface IAmmDataProvider {
         uint256 collateralTokenBalance,
         uint256 bTokenPrice,
         bool isBToken
+    ) external view returns (uint256);
+
+    function getCollateralValueOfAllExpiredOptionTokens(
+        uint64[] memory openSeries,
+        address ammAddress
+    ) external view returns (uint256);
+
+    function getOptionTokensSaleValue(
+        uint256 lpTokenAmount,
+        uint256 lpTokenSupply,
+        uint64[] memory openSeries,
+        address ammAddress,
+        uint256 collateralTokenBalance,
+        uint256 impliedVolatility
+    ) external view returns (uint256);
+
+    function getPriceForExpiredSeries(uint64 seriesId, uint256 volatilityFactor)
+        external
+        view
+        returns (uint256);
+
+    function getTotalPoolValue(
+        bool includeUnclaimed,
+        uint64[] memory openSeries,
+        uint256 collateralBalance,
+        address ammAddress,
+        uint256 impliedVolatility
     ) external view returns (uint256);
 }

--- a/contracts/amm/IAmmDataProvider.sol
+++ b/contracts/amm/IAmmDataProvider.sol
@@ -61,4 +61,10 @@ interface IAmmDataProvider {
         address ammAddress,
         uint256 impliedVolatility
     ) external view returns (uint256);
+
+    function getRedeemableCollateral(
+        uint64 seriesId,
+        uint256 wTokenBalance,
+        uint256 bTokenBalance
+    ) external view returns (uint256);
 }

--- a/scripts/lib/deploy_singleton_contracts.ts
+++ b/scripts/lib/deploy_singleton_contracts.ts
@@ -93,6 +93,7 @@ export async function deploySingletonContracts(
   const ammDataProvider = await AmmDataProvider.deploy(
     seriesController.address,
     erc1155Controller.address,
+    priceOracle.address,
   )
   console.log(
     "AmmDataProvider deployed to:         ",

--- a/test/amm/ammDataProviderUpdate.ts
+++ b/test/amm/ammDataProviderUpdate.ts
@@ -1,0 +1,86 @@
+import { expectEvent, expectRevert, BN } from "@openzeppelin/test-helpers"
+import { contract, assert } from "hardhat"
+import {
+  AmmDataProviderInstance,
+  AmmDataProviderContract,
+  ERC1155ControllerInstance,
+  MinterAmmInstance,
+  PriceOracleInstance,
+  SeriesControllerInstance,
+} from "../../typechain"
+import { constants } from "@openzeppelin/test-helpers"
+import { setupAllTestContracts } from "../util"
+
+const ERROR_MESSAGES = {
+  UNAUTHORIZED: "Ownable: caller is not the owner",
+}
+
+/**
+ * Testing MinterAmm AmmDataProvider  updates
+ */
+contract("MinterAmm AmmDataProvider", (accounts) => {
+  const ownerAccount = accounts[0]
+  const bobAccount = accounts[2]
+
+  const AmmDataProvider: AmmDataProviderContract =
+    artifacts.require("AmmDataProvider")
+
+  let deployedAmm: MinterAmmInstance
+  let deployedSeriesController: SeriesControllerInstance
+  let deployedERC1155Controller: ERC1155ControllerInstance
+  let deployedAmmDataProvider: AmmDataProviderInstance
+  let newDeployedAmmDataProvider: AmmDataProviderInstance
+  let deployedPriceOracle: PriceOracleInstance
+
+  beforeEach(async () => {
+    ;({
+      deployedAmm,
+      deployedSeriesController,
+      deployedERC1155Controller,
+      deployedAmmDataProvider,
+      deployedPriceOracle,
+    } = await setupAllTestContracts({}))
+
+    newDeployedAmmDataProvider = await AmmDataProvider.new(
+      deployedSeriesController.address,
+      deployedERC1155Controller.address,
+      deployedPriceOracle.address,
+    )
+  })
+
+  it("Correctly updates", async () => {
+    // Ensure an non-owner can't edit the data provider
+    await expectRevert(
+      deployedAmm.updateAmmDataProvider(newDeployedAmmDataProvider.address, {
+        from: bobAccount,
+      }),
+      ERROR_MESSAGES.UNAUTHORIZED,
+    )
+
+    // Ensure non-zero address
+    await expectRevert(
+      deployedAmm.updateAmmDataProvider(constants.ZERO_ADDRESS, {
+        from: ownerAccount,
+      }),
+      "E14", // Invalid _ammDataProvider
+    )
+
+    // Set it with the owner account
+    let ret = await deployedAmm.updateAmmDataProvider(
+      newDeployedAmmDataProvider.address,
+      {
+        from: ownerAccount,
+      },
+    )
+    expectEvent(ret, "NewAmmDataProvider", {
+      newAmmDataProvider: newDeployedAmmDataProvider.address,
+    })
+
+    // Verify it got set correctly
+    assert.equal(
+      await deployedAmm.ammDataProvider(),
+      newDeployedAmmDataProvider.address,
+      "New AmmDataProvider should be set",
+    )
+  })
+})

--- a/test/util.ts
+++ b/test/util.ts
@@ -301,11 +301,6 @@ export async function setupSingletonTestContracts(
     deployedSeriesController.address,
   )
 
-  const deployedAmmDataProvider = await AmmDataProvider.new(
-    deployedSeriesController.address,
-    deployedERC1155Controller.address,
-  )
-
   // create mock price oracle
   const deployedMockPriceOracle = await MockPriceOracle.new(
     await underlyingToken.decimals(),
@@ -335,6 +330,13 @@ export async function setupSingletonTestContracts(
     priceToken.address,
     deployedMockPriceOracle.address,
   )
+
+  const deployedAmmDataProvider = await AmmDataProvider.new(
+    deployedSeriesController.address,
+    deployedERC1155Controller.address,
+    deployedPriceOracle.address,
+  )
+
   const controllerInitResp =
     await deployedSeriesController.__SeriesController_init(
       deployedPriceOracle.address,


### PR DESCRIPTION
order to reduce the deployed bytecode size of the MinterAmm

    getTotalPoolValue
    getOptionTokensSaleValue
    getCollateralValueOfAllExpiredOptionTokens
    getRedeemableCollateral

This commit reduced the bytecode size by ~2400 bytes; from 24399 to 21982

This is backwards compatible because we keep all the existing
external/public MinterAmm functions the same, but their implementations
call out to the AmmDataProvider.

Finally, gas usage did not change noticeably except for the
withdrawCapital function.