### PR TITLE
Add transaction hash to the AMM events

### DIFF
--- a/subgraph/README.md
+++ b/subgraph/README.md
@@ -16,6 +16,20 @@ npm run build
 npm run deploy-<THE_TESTNET_NETWORK_NAME>
 ```
 
+#### Testing Locally with Real Data
+
+If you want to test the subgraph locally with real data, you can run ganache locally forked from mumbai testnet (polygon)
+
+```
+ganache-cli --fork https://polygon-mumbai.infura.io/v3/INFURA_KEY
+```
+
+Once this is running you can deploy the subgraph locally. The only other thing you need to do is copy the params from `./config/mumbai` to `./config/local.json` and leave the network as `mainnet`.
+
+Then deploy it as normal with `npm run deploy-local`
+
+The data from the testnet chain will get processed and scan after some time and you should be able to query the subgraph.
+
 #### View Subgraph Indexing Status
 
 To view the progress of your subgraph's deploy, and see any errors that may occur while it's indexing, you can use a GraphQL client (such as [GraphiQL](https://graphql-dotnet.github.io/docs/getting-started/graphiql/)) to query the status of the deploy.

--- a/subgraph/generated/AmmFactory/AmmFactory.ts
+++ b/subgraph/generated/AmmFactory/AmmFactory.ts
@@ -276,20 +276,24 @@ export class CreateAmmCall__Inputs {
     return this._call.inputValues[0].value.toAddress();
   }
 
-  get _underlyingToken(): Address {
+  get _ammDataProvider(): Address {
     return this._call.inputValues[1].value.toAddress();
   }
 
-  get _priceToken(): Address {
+  get _underlyingToken(): Address {
     return this._call.inputValues[2].value.toAddress();
   }
 
-  get _collateralToken(): Address {
+  get _priceToken(): Address {
     return this._call.inputValues[3].value.toAddress();
   }
 
+  get _collateralToken(): Address {
+    return this._call.inputValues[4].value.toAddress();
+  }
+
   get _tradeFeeBasisPoints(): i32 {
-    return this._call.inputValues[4].value.toI32();
+    return this._call.inputValues[5].value.toI32();
   }
 }
 

--- a/subgraph/generated/schema.ts
+++ b/subgraph/generated/schema.ts
@@ -2689,6 +2689,15 @@ export class LpTokenMinted extends Entity {
   set poolValueSnapshot(value: string) {
     this.set("poolValueSnapshot", Value.fromString(value));
   }
+
+  get transaction(): string {
+    let value = this.get("transaction");
+    return value.toString();
+  }
+
+  set transaction(value: string) {
+    this.set("transaction", Value.fromString(value));
+  }
 }
 
 export class LpTokenBurned extends Entity {
@@ -2791,6 +2800,15 @@ export class LpTokenBurned extends Entity {
 
   set poolValueSnapshot(value: string) {
     this.set("poolValueSnapshot", Value.fromString(value));
+  }
+
+  get transaction(): string {
+    let value = this.get("transaction");
+    return value.toString();
+  }
+
+  set transaction(value: string) {
+    this.set("transaction", Value.fromString(value));
   }
 }
 
@@ -2904,6 +2922,15 @@ export class BTokenBought extends Entity {
   set seriesId(value: i32) {
     this.set("seriesId", Value.fromI32(value));
   }
+
+  get transaction(): string {
+    let value = this.get("transaction");
+    return value.toString();
+  }
+
+  set transaction(value: string) {
+    this.set("transaction", Value.fromString(value));
+  }
 }
 
 export class BTokenSold extends Entity {
@@ -3016,6 +3043,15 @@ export class BTokenSold extends Entity {
   set seriesId(value: i32) {
     this.set("seriesId", Value.fromI32(value));
   }
+
+  get transaction(): string {
+    let value = this.get("transaction");
+    return value.toString();
+  }
+
+  set transaction(value: string) {
+    this.set("transaction", Value.fromString(value));
+  }
 }
 
 export class WTokenSold extends Entity {
@@ -3127,6 +3163,15 @@ export class WTokenSold extends Entity {
 
   set seriesId(value: i32) {
     this.set("seriesId", Value.fromI32(value));
+  }
+
+  get transaction(): string {
+    let value = this.get("transaction");
+    return value.toString();
+  }
+
+  set transaction(value: string) {
+    this.set("transaction", Value.fromString(value));
   }
 }
 

--- a/subgraph/generated/templates/Amm/MinterAmm.ts
+++ b/subgraph/generated/templates/Amm/MinterAmm.ts
@@ -166,6 +166,24 @@ export class LpTokensMinted__Params {
   }
 }
 
+export class NewAmmDataProvider extends ethereum.Event {
+  get params(): NewAmmDataProvider__Params {
+    return new NewAmmDataProvider__Params(this);
+  }
+}
+
+export class NewAmmDataProvider__Params {
+  _event: NewAmmDataProvider;
+
+  constructor(event: NewAmmDataProvider) {
+    this._event = event;
+  }
+
+  get newAmmDataProvider(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+}
+
 export class NewSirenPriceOracle extends ethereum.Event {
   get params(): NewSirenPriceOracle__Params {
     return new NewSirenPriceOracle__Params(this);
@@ -221,6 +239,54 @@ export class SeriesEvicted__Params {
 
   get seriesId(): BigInt {
     return this._event.parameters[0].value.toBigInt();
+  }
+}
+
+export class TradeFeesPaid extends ethereum.Event {
+  get params(): TradeFeesPaid__Params {
+    return new TradeFeesPaid__Params(this);
+  }
+}
+
+export class TradeFeesPaid__Params {
+  _event: TradeFeesPaid;
+
+  constructor(event: TradeFeesPaid) {
+    this._event = event;
+  }
+
+  get feePaidTo(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get feeAmount(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
+  }
+}
+
+export class TradeFeesUpdated extends ethereum.Event {
+  get params(): TradeFeesUpdated__Params {
+    return new TradeFeesUpdated__Params(this);
+  }
+}
+
+export class TradeFeesUpdated__Params {
+  _event: TradeFeesUpdated;
+
+  constructor(event: TradeFeesUpdated) {
+    this._event = event;
+  }
+
+  get newTradeFeeBasisPoints(): i32 {
+    return this._event.parameters[0].value.toI32();
+  }
+
+  get newMaxOptionFeeBasisPoints(): i32 {
+    return this._event.parameters[1].value.toI32();
+  }
+
+  get newFeeDestinationAddress(): Address {
+    return this._event.parameters[2].value.toAddress();
   }
 }
 
@@ -349,6 +415,29 @@ export class MinterAmm extends ethereum.SmartContract {
     return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
+  ammDataProvider(): Address {
+    let result = super.call(
+      "ammDataProvider",
+      "ammDataProvider():(address)",
+      []
+    );
+
+    return result[0].toAddress();
+  }
+
+  try_ammDataProvider(): ethereum.CallResult<Address> {
+    let result = super.tryCall(
+      "ammDataProvider",
+      "ammDataProvider():(address)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
+  }
+
   bTokenBuy(
     seriesId: BigInt,
     bTokenAmount: BigInt,
@@ -420,6 +509,41 @@ export class MinterAmm extends ethereum.SmartContract {
     return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
+  bTokenGetCollateralInWithoutFees(
+    seriesId: BigInt,
+    bTokenAmount: BigInt
+  ): BigInt {
+    let result = super.call(
+      "bTokenGetCollateralInWithoutFees",
+      "bTokenGetCollateralInWithoutFees(uint64,uint256):(uint256)",
+      [
+        ethereum.Value.fromUnsignedBigInt(seriesId),
+        ethereum.Value.fromUnsignedBigInt(bTokenAmount)
+      ]
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_bTokenGetCollateralInWithoutFees(
+    seriesId: BigInt,
+    bTokenAmount: BigInt
+  ): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "bTokenGetCollateralInWithoutFees",
+      "bTokenGetCollateralInWithoutFees(uint64,uint256):(uint256)",
+      [
+        ethereum.Value.fromUnsignedBigInt(seriesId),
+        ethereum.Value.fromUnsignedBigInt(bTokenAmount)
+      ]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
   bTokenGetCollateralOut(seriesId: BigInt, bTokenAmount: BigInt): BigInt {
     let result = super.call(
       "bTokenGetCollateralOut",
@@ -440,6 +564,41 @@ export class MinterAmm extends ethereum.SmartContract {
     let result = super.tryCall(
       "bTokenGetCollateralOut",
       "bTokenGetCollateralOut(uint64,uint256):(uint256)",
+      [
+        ethereum.Value.fromUnsignedBigInt(seriesId),
+        ethereum.Value.fromUnsignedBigInt(bTokenAmount)
+      ]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  bTokenGetCollateralOutWithoutFees(
+    seriesId: BigInt,
+    bTokenAmount: BigInt
+  ): BigInt {
+    let result = super.call(
+      "bTokenGetCollateralOutWithoutFees",
+      "bTokenGetCollateralOutWithoutFees(uint64,uint256):(uint256)",
+      [
+        ethereum.Value.fromUnsignedBigInt(seriesId),
+        ethereum.Value.fromUnsignedBigInt(bTokenAmount)
+      ]
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_bTokenGetCollateralOutWithoutFees(
+    seriesId: BigInt,
+    bTokenAmount: BigInt
+  ): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "bTokenGetCollateralOutWithoutFees",
+      "bTokenGetCollateralOutWithoutFees(uint64,uint256):(uint256)",
       [
         ethereum.Value.fromUnsignedBigInt(seriesId),
         ethereum.Value.fromUnsignedBigInt(bTokenAmount)
@@ -538,6 +697,38 @@ export class MinterAmm extends ethereum.SmartContract {
     return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
+  calculateFees(bTokenAmount: BigInt, collateralAmount: BigInt): BigInt {
+    let result = super.call(
+      "calculateFees",
+      "calculateFees(uint256,uint256):(uint256)",
+      [
+        ethereum.Value.fromUnsignedBigInt(bTokenAmount),
+        ethereum.Value.fromUnsignedBigInt(collateralAmount)
+      ]
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_calculateFees(
+    bTokenAmount: BigInt,
+    collateralAmount: BigInt
+  ): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "calculateFees",
+      "calculateFees(uint256,uint256):(uint256)",
+      [
+        ethereum.Value.fromUnsignedBigInt(bTokenAmount),
+        ethereum.Value.fromUnsignedBigInt(collateralAmount)
+      ]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
   collateralToken(): Address {
     let result = super.call(
       "collateralToken",
@@ -575,6 +766,29 @@ export class MinterAmm extends ethereum.SmartContract {
     let result = super.tryCall(
       "erc1155Controller",
       "erc1155Controller():(address)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
+  }
+
+  feeDestinationAddress(): Address {
+    let result = super.call(
+      "feeDestinationAddress",
+      "feeDestinationAddress():(address)",
+      []
+    );
+
+    return result[0].toAddress();
+  }
+
+  try_feeDestinationAddress(): ethereum.CallResult<Address> {
+    let result = super.tryCall(
+      "feeDestinationAddress",
+      "feeDestinationAddress():(address)",
       []
     );
     if (result.reverted) {
@@ -793,6 +1007,29 @@ export class MinterAmm extends ethereum.SmartContract {
     }
     let value = result.value;
     return ethereum.CallResult.fromValue(value[0].toAddress());
+  }
+
+  maxOptionFeeBasisPoints(): i32 {
+    let result = super.call(
+      "maxOptionFeeBasisPoints",
+      "maxOptionFeeBasisPoints():(uint16)",
+      []
+    );
+
+    return result[0].toI32();
+  }
+
+  try_maxOptionFeeBasisPoints(): ethereum.CallResult<i32> {
+    let result = super.tryCall(
+      "maxOptionFeeBasisPoints",
+      "maxOptionFeeBasisPoints():(uint16)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
   }
 
   onERC1155BatchReceived(
@@ -1320,24 +1557,28 @@ export class InitializeCall__Inputs {
     return this._call.inputValues[1].value.toAddress();
   }
 
-  get _underlyingToken(): Address {
+  get _ammDataProvider(): Address {
     return this._call.inputValues[2].value.toAddress();
   }
 
-  get _priceToken(): Address {
+  get _underlyingToken(): Address {
     return this._call.inputValues[3].value.toAddress();
   }
 
-  get _collateralToken(): Address {
+  get _priceToken(): Address {
     return this._call.inputValues[4].value.toAddress();
   }
 
-  get _tokenImplementation(): Address {
+  get _collateralToken(): Address {
     return this._call.inputValues[5].value.toAddress();
   }
 
+  get _tokenImplementation(): Address {
+    return this._call.inputValues[6].value.toAddress();
+  }
+
   get _tradeFeeBasisPoints(): i32 {
-    return this._call.inputValues[6].value.toI32();
+    return this._call.inputValues[7].value.toI32();
   }
 }
 
@@ -1509,6 +1750,44 @@ export class RenounceOwnershipCall__Outputs {
   }
 }
 
+export class SetTradingFeeParamsCall extends ethereum.Call {
+  get inputs(): SetTradingFeeParamsCall__Inputs {
+    return new SetTradingFeeParamsCall__Inputs(this);
+  }
+
+  get outputs(): SetTradingFeeParamsCall__Outputs {
+    return new SetTradingFeeParamsCall__Outputs(this);
+  }
+}
+
+export class SetTradingFeeParamsCall__Inputs {
+  _call: SetTradingFeeParamsCall;
+
+  constructor(call: SetTradingFeeParamsCall) {
+    this._call = call;
+  }
+
+  get _tradeFeeBasisPoints(): i32 {
+    return this._call.inputValues[0].value.toI32();
+  }
+
+  get _maxOptionFeeBasisPoints(): i32 {
+    return this._call.inputValues[1].value.toI32();
+  }
+
+  get _feeDestinationAddress(): Address {
+    return this._call.inputValues[2].value.toAddress();
+  }
+}
+
+export class SetTradingFeeParamsCall__Outputs {
+  _call: SetTradingFeeParamsCall;
+
+  constructor(call: SetTradingFeeParamsCall) {
+    this._call = call;
+  }
+}
+
 export class SetVolatilityFactorCall extends ethereum.Call {
   get inputs(): SetVolatilityFactorCall__Inputs {
     return new SetVolatilityFactorCall__Inputs(this);
@@ -1565,6 +1844,36 @@ export class TransferOwnershipCall__Outputs {
   _call: TransferOwnershipCall;
 
   constructor(call: TransferOwnershipCall) {
+    this._call = call;
+  }
+}
+
+export class UpdateAmmDataProviderCall extends ethereum.Call {
+  get inputs(): UpdateAmmDataProviderCall__Inputs {
+    return new UpdateAmmDataProviderCall__Inputs(this);
+  }
+
+  get outputs(): UpdateAmmDataProviderCall__Outputs {
+    return new UpdateAmmDataProviderCall__Outputs(this);
+  }
+}
+
+export class UpdateAmmDataProviderCall__Inputs {
+  _call: UpdateAmmDataProviderCall;
+
+  constructor(call: UpdateAmmDataProviderCall) {
+    this._call = call;
+  }
+
+  get _newAmmDataProvider(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+}
+
+export class UpdateAmmDataProviderCall__Outputs {
+  _call: UpdateAmmDataProviderCall;
+
+  constructor(call: UpdateAmmDataProviderCall) {
     this._call = call;
   }
 }

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -483,6 +483,8 @@ interface AmmTokenEvent {
   block: BigInt!
   timestamp: BigInt!
   poolValueSnapshot: PoolValueSnapshot!
+  # Transaction hash for this event
+  transaction: String!
 }
 
 type LpTokenMinted implements AmmTokenEvent @entity {
@@ -495,6 +497,7 @@ type LpTokenMinted implements AmmTokenEvent @entity {
   block: BigInt!
   timestamp: BigInt!
   poolValueSnapshot: PoolValueSnapshot!
+  transaction: String!
 }
 type LpTokenBurned implements AmmTokenEvent @entity {
   id: ID!
@@ -506,6 +509,7 @@ type LpTokenBurned implements AmmTokenEvent @entity {
   block: BigInt!
   timestamp: BigInt!
   poolValueSnapshot: PoolValueSnapshot!
+  transaction: String!
 }
 type BTokenBought implements AmmTokenEvent @entity {
   id: ID!
@@ -518,6 +522,7 @@ type BTokenBought implements AmmTokenEvent @entity {
   timestamp: BigInt!
   poolValueSnapshot: PoolValueSnapshot!
   seriesId: Int!
+  transaction: String!
 }
 type BTokenSold implements AmmTokenEvent @entity {
   id: ID!
@@ -530,6 +535,7 @@ type BTokenSold implements AmmTokenEvent @entity {
   timestamp: BigInt!
   poolValueSnapshot: PoolValueSnapshot!
   seriesId: Int!
+  transaction: String!
 }
 type WTokenSold implements AmmTokenEvent @entity {
   id: ID!
@@ -542,6 +548,7 @@ type WTokenSold implements AmmTokenEvent @entity {
   timestamp: BigInt!
   poolValueSnapshot: PoolValueSnapshot!
   seriesId: Int!
+  transaction: String!
 }
 
 #

--- a/subgraph/src/mappings/amm.ts
+++ b/subgraph/src/mappings/amm.ts
@@ -77,6 +77,7 @@ export function handleLpTokensMinted(event: LpTokensMinted): void {
   lpTokenMinted.block = event.block.number
   lpTokenMinted.timestamp = event.block.timestamp
   lpTokenMinted.poolValueSnapshot = poolValueSnapShot.id
+  lpTokenMinted.transaction = event.transaction.hash.toHex()
 
   lpTokenMinted.save()
 }
@@ -94,6 +95,7 @@ export function handleLpTokensBurned(event: LpTokensBurned): void {
   lpTokenBurned.block = event.block.number
   lpTokenBurned.timestamp = event.block.timestamp
   lpTokenBurned.poolValueSnapshot = poolValueSnapShot.id
+  lpTokenBurned.transaction = event.transaction.hash.toHex()
 
   lpTokenBurned.save()
 
@@ -113,6 +115,7 @@ export function handleBTokensBought(event: BTokensBought): void {
   bTokenBought.timestamp = event.block.timestamp
   bTokenBought.poolValueSnapshot = poolValueSnapShot.id
   bTokenBought.seriesId = event.params.seriesId.toI32()
+  bTokenBought.transaction = event.transaction.hash.toHex()
 
   bTokenBought.save()
 }
@@ -132,6 +135,7 @@ export function handleBTokensSold(event: BTokensSold): void {
   bTokenSold.timestamp = event.block.timestamp
   bTokenSold.poolValueSnapshot = poolValueSnapShot.id
   bTokenSold.seriesId = event.params.seriesId.toI32()
+  bTokenSold.transaction = event.transaction.hash.toHex()
 
   bTokenSold.save()
 }
@@ -151,13 +155,14 @@ export function handleWTokensSold(event: WTokensSold): void {
   wTokenSold.timestamp = event.block.timestamp
   wTokenSold.poolValueSnapshot = poolValueSnapShot.id
   wTokenSold.seriesId = event.params.seriesId.toI32()
+  wTokenSold.transaction = event.transaction.hash.toHex()
 
   wTokenSold.save()
 }
 
 function takePoolValueSnapshot(event: ethereum.Event): PoolValueSnapshot {
   let poolValueSnapshot = new PoolValueSnapshot(getId(event))
- 
+
   let ammContract = AmmContract.bind(event.address)
   let lpTokenContract = SimpleTokenContract.bind(ammContract.lpToken())
 


### PR DESCRIPTION
This addresses issue #70 .

The changes here will add a new `transaction` field to the AMM events so we can show historical transaction activity against an AMM.

It looks like some of the generated files were out of date so they got picked up as well.

Added notes in the README for the subgraph about how to test locally with real data as well.

The main changes were done in `subgraph/schema.graphql`.  Most other files are auto generated.