### PR TITLE
Ensure token pairs start with valid price

### DIFF
--- a/contracts/series/PriceOracle.sol
+++ b/contracts/series/PriceOracle.sol
@@ -227,7 +227,13 @@ contract PriceOracle is IPriceOracle, OwnableUpgradeable, Proxiable {
         // set the pair's oracle on the PriceOracle
         oracles[underlyingToken][priceToken] = oracle;
 
+        // Get the price and ensure it is valid
         uint256 currentPrice = getCurrentPrice(underlyingToken, priceToken);
+        require(
+            currentPrice > 0,
+            "price oracle must start with a valid price feed"
+        );
+
         // We need to initially set the price on some offset-aligned date prior to the current date, so that
         // in the loop in PriceOracle.setSettlementDate it will eventually stop looping when it finds a
         // non-zero price. If we do not add set this price, then the first call to PriceOracle.setSettlementDate the first

--- a/test/seriesController/priceOracle.ts
+++ b/test/seriesController/priceOracle.ts
@@ -78,6 +78,27 @@ contract("PriceOracle verification", (accounts) => {
       )
     })
 
+    it("should fail if the oracle returns a 0 value when adding a token pair", async () => {
+      // Create a new token so the oracle can be set
+      let firstToken = await SimpleToken.new()
+      await firstToken.initialize("USD Coin", "USDC", 6)
+
+      let secondToken = await SimpleToken.new()
+      await secondToken.initialize("USD Coin", "USDC", 6)
+
+      // Set the next price to 0
+      await deployedMockPriceOracle.setLatestAnswer(0)
+
+      await expectRevert(
+        deployedPriceOracle.addTokenPair(
+          secondToken.address,
+          firstToken.address,
+          deployedMockPriceOracle.address,
+        ),
+        "price oracle must start with a valid price feed",
+      )
+    })
+
     it("should fail to set settlement price before setting an oracle", async () => {
       const priceOracleLogic = await PriceOracle.new()
       const proxyContract = await Proxy.new(priceOracleLogic.address)


### PR DESCRIPTION
Fixes issue #67 .

When adding a new token pair, the solidity code will now ensure it starts with a valid price.  If the oracle returns `0` it will revert the tx.

Unit test added to verify.