### PR TITLE
Expiration Validation and Expiration IDs

### DIFF
--- a/contracts/series/ISeriesController.sol
+++ b/contracts/series/ISeriesController.sol
@@ -132,6 +132,9 @@ interface ISeriesController {
         uint256 collateralAmount
     );
 
+    /** Emitted when the owner adds new allowed expirations */
+    event AllowedExpirationUpdated(uint256 newAllowedExpiration);
+
     ///////////////////// VIEW/PURE FUNCTIONS /////////////////////
 
     function priceDecimals() external view returns (uint8);

--- a/contracts/series/SeriesController.sol
+++ b/contracts/series/SeriesController.sol
@@ -812,12 +812,11 @@ contract SeriesController is
         // validate price and expiration
         require(_strikePrice != 0, "Invalid _strikePrice");
         require(_expirationDate > block.timestamp, "Invalid _expirationDate");
+
+        // Validate the expiration has been added to the list by the owner
         require(
-            _expirationDate ==
-                IPriceOracle(priceOracle).get8amWeeklyOrDailyAligned(
-                    _expirationDate
-                ),
-            "Nonaligned"
+            allowedExpirationsMap[_expirationDate] > 0,
+            "_expirationDate not set"
         );
 
         return
@@ -1169,12 +1168,16 @@ contract SeriesController is
         // Save off the expiration list length as the next expiration ID to be added
         uint256 nextExpirationID = allowedExpirationsList.length;
 
+        // First time through, increment counter since we don't want to allow an ID of 0
+        if (nextExpirationID == 0) {
+            allowedExpirationsList.push(0);
+            nextExpirationID++;
+        }
+
         for (uint256 i = 0; i < timestamps.length; i++) {
             // Verify the next timestamp added is newer than the last one (empty should return 0)
             require(
-                (nextExpirationID == 0) ||
-                    (allowedExpirationsList[nextExpirationID - 1] <
-                        timestamps[i]),
+                (allowedExpirationsList[nextExpirationID - 1] < timestamps[i]),
                 "Order!"
             );
 

--- a/contracts/series/SeriesController.sol
+++ b/contracts/series/SeriesController.sol
@@ -39,10 +39,10 @@ import "./SeriesControllerStorage.sol";
 /// on gas deployment costs by storing individual Series structs in an array
 contract SeriesController is
     Initializable,
-    SeriesControllerStorageV1,
     PausableUpgradeable,
     AccessControlUpgradeable,
-    Proxiable
+    Proxiable,
+    SeriesControllerStorageV1
 {
     /** Use safe ERC20 functions for any token transfers since people don't follow the ERC20 standard */
     using SafeERC20 for IERC20;

--- a/contracts/series/SeriesControllerStorage.sol
+++ b/contracts/series/SeriesControllerStorage.sol
@@ -56,11 +56,14 @@ abstract contract SeriesControllerStorageV1 is ISeriesController {
     /// @dev Stores the allowed expiration dates for series created by the auto series creation feature
     // Mapping is (ExpirationDate => ExpirationID); If the expiration ID is not 0 then it is a valid expiration date.
     // This is a convenience lookup mapping -> corresponds with allowedExpirationsList
+    // ExpirationID lookup of value 0 means it is not set
     mapping(uint256 => uint256) public allowedExpirationsMap;
 
     /// @dev Stores an array of allowed expirations.
     // The index in the array is the ExpirationID, the value is the ExpirationDate
     // This is a convenience lookup array -> corresponds with allowedExpirations
+    // @note The 0th element in the list (first one) is a place holder, since we do not want any
+    // expirations with ID 0 (we need to verify in the mapping that 0 means it is not set)
     uint256[] public allowedExpirationsList;
 }
 

--- a/contracts/series/SeriesControllerStorage.sol
+++ b/contracts/series/SeriesControllerStorage.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.0;
+
+import "./ISeriesController.sol";
+
+/// This contract stores all new local variables for the SeriesController.sol contract.
+/// This allows us to upgrade the contract and add new variables without worrying about
+///   memory layout when we add new variables.
+/// Each time a new version is created with new variables, the version "V1, V2, etc" should
+//    be bumped and inherit from the previous version, and the MinterAmm should inherit from
+///   the newest version.
+abstract contract SeriesControllerStorageV1 is ISeriesController {
+    /// @dev The price oracle consulted for any price data needed by the individual Series
+    address internal priceOracle;
+
+    /// @dev The address of the SeriesVault that stores all of this SeriesController's tokens
+    address internal vault;
+
+    /// @dev The fees charged for different methods on the SeriesController
+    ISeriesController.Fees internal fees;
+
+    /// @notice Monotonically incrementing index, used when creating Series.
+    uint64 public latestIndex;
+
+    /// @dev The address of the ERC1155Controler that performs minting and burning of option tokens
+    address public override erc1155Controller;
+
+    /// @dev An array of all the Series structs ever created by the SeriesController
+    ISeriesController.Series[] internal allSeries;
+
+    /// @dev Stores the balance of a Series' ERC20 collateralToken
+    /// e.g. seriesBalances[_seriesId] = 1,337,000,000
+    mapping(uint64 => uint256) internal seriesBalances;
+
+    /// @dev Price decimals
+    uint8 public constant override priceDecimals = 8;
+
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    /// @dev These contract variables, as well as the `nonReentrant` modifier further down below,
+    /// are copied from OpenZeppelin's ReentrancyGuard contract. We chose to copy ReentrancyGuard instead of
+    /// having SeriesController inherit it because we intend use this SeriesController contract to upgrade already-deployed
+    /// SeriesController contracts. If the SeriesController were to inherit from ReentrancyGuard, the ReentrancyGuard's
+    /// contract storage variables would overwrite existing storage variables on the contract and it would
+    /// break the contract. So by manually implementing ReentrancyGuard's logic we have full control over
+    /// the position of the variable in the contract's storage, and we can ensure the SeriesController's contract
+    /// storage variables are only ever appended to. See this OpenZeppelin article about contract upgradeability
+    /// for more info on the contract storage variable requirement:
+    /// https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#modifying-your-contracts
+    uint256 internal constant _NOT_ENTERED = 1;
+    uint256 internal constant _ENTERED = 2;
+    uint256 internal _status;
+
+    /// @dev Stores the allowed expiration dates for series created by the auto series creation feature
+    // Mapping is (ExpirationDate => ExpirationID); If the expiration ID is not 0 then it is a valid expiration date.
+    // This is a convenience lookup mapping -> corresponds with allowedExpirationsList
+    mapping(uint256 => uint256) public allowedExpirationsMap;
+
+    /// @dev Stores an array of allowed expirations.
+    // The index in the array is the ExpirationID, the value is the ExpirationDate
+    // This is a convenience lookup array -> corresponds with allowedExpirations
+    uint256[] public allowedExpirationsList;
+}
+
+// Next version example:
+/// contract SeriesControllerStorageV2 is SeriesControllerStorageV1 {
+///   address public myAddress;
+/// }
+/// Then... SeriesController should inherit from SeriesControllerStorageV2

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,6 +6,7 @@ import "hardhat-log-remover"
 import "uniswap-v3-deploy-plugin"
 import "hardhat-contract-sizer"
 import "@nomiclabs/hardhat-etherscan"
+import "hardhat-storage-layout"
 
 import { HardhatUserConfig } from "hardhat/types"
 
@@ -38,6 +39,11 @@ const config: HardhatUserConfig = {
             enabled: true,
             runs: 1,
           },
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
+          },
         },
       },
       {
@@ -46,6 +52,11 @@ const config: HardhatUserConfig = {
           optimizer: {
             enabled: true,
             runs: 1,
+          },
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
           },
         },
       },
@@ -56,6 +67,11 @@ const config: HardhatUserConfig = {
             enabled: true,
             runs: 1,
           },
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
+          },
         },
       },
       {
@@ -64,6 +80,11 @@ const config: HardhatUserConfig = {
           optimizer: {
             enabled: true,
             runs: 1,
+          },
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
           },
         },
       },
@@ -74,6 +95,11 @@ const config: HardhatUserConfig = {
             enabled: true,
             runs: 1,
           },
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
+          },
         },
       },
       {
@@ -82,6 +108,11 @@ const config: HardhatUserConfig = {
           optimizer: {
             enabled: true,
             runs: 1,
+          },
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
           },
         },
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "hardhat-contract-sizer": "^2.0.3",
         "hardhat-log-remover": "^2.0.0",
         "hardhat-preprocessor": "^0.1.2",
+        "hardhat-storage-layout": "^0.1.6",
         "husky": "^7.0.1",
         "prettier": "^2.3.2",
         "prettier-plugin-solidity": "^1.0.0-beta.17",
@@ -5451,6 +5452,15 @@
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
     },
+    "node_modules/console-table-printer": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.10.0.tgz",
+      "integrity": "sha512-7pTsysaJs1+R+OO4cCtJbl+Lr4piHYIhi7/V1qHbOg/uiYgq2yUINFgvXZtVHqm9qpW0+Uk190qkGcKvzdunvg==",
+      "dev": true,
+      "dependencies": {
+        "simple-wcswidth": "^1.0.1"
+      }
+    },
     "node_modules/constant-case": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
@@ -9401,6 +9411,18 @@
       },
       "peerDependencies": {
         "hardhat": "^2.0.5"
+      }
+    },
+    "node_modules/hardhat-storage-layout": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/hardhat-storage-layout/-/hardhat-storage-layout-0.1.6.tgz",
+      "integrity": "sha512-urp9PUDJmRrFaTnMkyYGAlU0OF7Q+inWMWKHvuGRyvBDwVQKXfj5WoerTax4bBpXukJ4fBYyUTjAr0x+j2LcKQ==",
+      "dev": true,
+      "dependencies": {
+        "console-table-printer": "^2.9.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.3"
       }
     },
     "node_modules/hardhat-watcher": {
@@ -14575,6 +14597,12 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "node_modules/simple-wcswidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz",
+      "integrity": "sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==",
+      "dev": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -23389,6 +23417,15 @@
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
     },
+    "console-table-printer": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.10.0.tgz",
+      "integrity": "sha512-7pTsysaJs1+R+OO4cCtJbl+Lr4piHYIhi7/V1qHbOg/uiYgq2yUINFgvXZtVHqm9qpW0+Uk190qkGcKvzdunvg==",
+      "dev": true,
+      "requires": {
+        "simple-wcswidth": "^1.0.1"
+      }
+    },
     "constant-case": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
@@ -26834,6 +26871,15 @@
       "dev": true,
       "requires": {
         "murmur-128": "^0.2.1"
+      }
+    },
+    "hardhat-storage-layout": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/hardhat-storage-layout/-/hardhat-storage-layout-0.1.6.tgz",
+      "integrity": "sha512-urp9PUDJmRrFaTnMkyYGAlU0OF7Q+inWMWKHvuGRyvBDwVQKXfj5WoerTax4bBpXukJ4fBYyUTjAr0x+j2LcKQ==",
+      "dev": true,
+      "requires": {
+        "console-table-printer": "^2.9.0"
       }
     },
     "hardhat-watcher": {
@@ -30749,6 +30795,12 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "simple-wcswidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz",
+      "integrity": "sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==",
+      "dev": true
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "clean:dependencies": "rm -rf ./node_modules && rm -rf ./*/**/node_modules",
     "clean:dist": "rm -rf ./dist/** && rm -rf ./src/ethers/**",
     "clean": "npx hardhat clean && npm run clean:dist && npm run clean:dependencies",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "storage-layout": "npx hardhat run ./scripts/storage_layout.ts"
   },
   "peerDependencies": {
     "ethers": ">5.0.0"
@@ -64,6 +65,7 @@
     "hardhat-contract-sizer": "^2.0.3",
     "hardhat-log-remover": "^2.0.0",
     "hardhat-preprocessor": "^0.1.2",
+    "hardhat-storage-layout": "^0.1.6",
     "husky": "^7.0.1",
     "prettier": "^2.3.2",
     "prettier-plugin-solidity": "^1.0.0-beta.17",

--- a/scripts/storage_layout.ts
+++ b/scripts/storage_layout.ts
@@ -1,0 +1,14 @@
+const hre = require("hardhat")
+
+async function main() {
+  await hre.storageLayout.export()
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/test/amm/minterAmmRemoveExpired.ts
+++ b/test/amm/minterAmmRemoveExpired.ts
@@ -139,6 +139,9 @@ contract("Minter AMM Remove expired series", (accounts) => {
   it("3 open series 2 expired series", async () => {
     // 3 series will have expiry of 32 days and 2 series will have expiry of 30 days
 
+    // Add the expirations
+    await deployedSeriesController.updateAllowedExpirations([expirationLong])
+
     const STRIKE_PRICE_2 = 15001 * 1e8
     const STRIKE_PRICE_3 = 15002 * 1e8
     const STRIKE_PRICE_4 = 15003 * 1e8
@@ -226,6 +229,9 @@ contract("Minter AMM Remove expired series", (accounts) => {
   it("1 open & 1 series expired(last one added to the open series)", async () => {
     const STRIKE_PRICE_2 = 15001 * 1e8
 
+    // Add the new expirations
+    await deployedSeriesController.updateAllowedExpirations([expirationLong])
+
     let ret = await deployedSeriesController.createSeries(
       {
         underlyingToken: collateralToken.address,
@@ -309,6 +315,9 @@ contract("Minter AMM Remove expired series", (accounts) => {
         skipCreateSeries: true,
       }))
       expirationLong = expiration + ONE_WEEK_DURATION
+
+      // Add the expirations
+      await deployedSeriesController.updateAllowedExpirations([expirationLong])
 
       let numClosedSeries = 0
 

--- a/test/seriesController/cashSettlement.ts
+++ b/test/seriesController/cashSettlement.ts
@@ -471,7 +471,7 @@ contract("Cash Settlement", (accounts) => {
     )
     await expectRevert(
       deployedSeriesController.claimCollateral(seriesId, MINT_AMOUNT),
-      "Option contract must be in EXPIRED State to claim collateral",
+      "Series Not Expired",
     )
 
     // Move the block time into the future so the contract is expired

--- a/test/seriesController/closeSeries.ts
+++ b/test/seriesController/closeSeries.ts
@@ -121,7 +121,7 @@ contract("SeriesController close", (accounts) => {
 
     await expectRevert(
       deployedSeriesController.closePosition(seriesId, MINT_AMOUNT),
-      "SeriesController: Option contract must be in Open State to close a position",
+      "Series Not Open",
     )
   })
 

--- a/test/seriesController/proxySeriesController.ts
+++ b/test/seriesController/proxySeriesController.ts
@@ -46,13 +46,10 @@ const STATE_EXPIRED = 1
 
 const ERROR_MESSAGES = {
   CANNOT_EXERCISE_EXPIRED: "Option contract must be in Open State to exercise",
-  CANNOT_EXERCISE_PRIOR_EXERCISE_WINDOW:
-    "Option contract must be in EXPIRED State to exercise",
-  CANNOT_CLAIM_OPEN:
-    "Option contract must be in EXPIRED State to claim collateral",
-  CANNOT_CLOSE_EXPIRED:
-    "Option contract must be in Open State to close a position",
-  CANNOT_MINT_NOT_OPEN: "Option contract must be in Open State to mint",
+  CANNOT_EXERCISE_PRIOR_EXERCISE_WINDOW: "Series Not Expired",
+  CANNOT_CLAIM_OPEN: "Series Not Expired",
+  CANNOT_CLOSE_EXPIRED: "Series Not Open",
+  CANNOT_MINT_NOT_OPEN: "Series Not Open",
   NOT_ENOUGH_BALANCE: "ERC20: transfer amount exceeds balance",
   NOT_APPROVED_BALANCE: "ERC20: transfer amount exceeds allowance",
   NON_MINTER: "mintOptions: only restrictedMinter can mint",
@@ -449,7 +446,7 @@ contract("Proxy Series Verification", (accounts) => {
         [],
         isPutOption,
       ),
-      "SeriesController: Must specify Series' restricted minters",
+      "Invalid _restrictedMinters",
     )
   })
 
@@ -507,13 +504,13 @@ contract("Proxy Series Verification", (accounts) => {
       deployedSeriesController.mintOptions(1337, MINT_AMOUNT, {
         from: aliceAccount,
       }),
-      "SeriesController: Series at this _seriesId does not exist",
+      "Invalid _seriesId",
     )
 
     // It should fail to mint when minter is not one of the restricted minters
     await expectRevert(
       deployedSeriesController.mintOptions(seriesId, MINT_AMOUNT),
-      "SeriesController: caller must have MINTER_ROLE",
+      "Not Minter Role",
     )
 
     // It should succeed

--- a/test/seriesController/seriesExpirations.ts
+++ b/test/seriesController/seriesExpirations.ts
@@ -23,31 +23,33 @@ contract("Series Expirations", (accounts) => {
     ;({ deployedSeriesController, expiration } =
       await setupSingletonTestContracts())
 
+    const date1 = getNextFriday8amUTCTimestamp(expiration + 1000)
+
     // Verify ownership check
     await expectRevert(
-      deployedSeriesController.updateAllowedExpirations([expiration], {
+      deployedSeriesController.updateAllowedExpirations([date1], {
         from: aliceAccount,
       }),
       "SeriesController: Caller is not the owner",
     )
 
     // Verify setting an expiration works from owner acct
-    await deployedSeriesController.updateAllowedExpirations([expiration])
+    await deployedSeriesController.updateAllowedExpirations([date1])
 
     // Verify adding the same one doesn't work since it is not greater than the last
     await expectRevert(
-      deployedSeriesController.updateAllowedExpirations([expiration]),
+      deployedSeriesController.updateAllowedExpirations([date1]),
       "Order!",
     )
 
     // Verify adding a later non-aligned (not 8 AM) gets rejected
     await expectRevert(
-      deployedSeriesController.updateAllowedExpirations([expiration + 500]),
+      deployedSeriesController.updateAllowedExpirations([date1 + 500]),
       "Nonaligned",
     )
 
     // Add a second and third one
-    const date2 = getNextFriday8amUTCTimestamp(expiration + 1000)
+    const date2 = getNextFriday8amUTCTimestamp(date1 + 1000)
     const date3 = getNextFriday8amUTCTimestamp(date2 + 1000)
     let ret = await deployedSeriesController.updateAllowedExpirations([
       date2,
@@ -65,32 +67,43 @@ contract("Series Expirations", (accounts) => {
     // Verify the list and map are updated
     assertBNEq(
       await deployedSeriesController.allowedExpirationsMap(expiration),
-      0,
-      "map should be set",
-    )
-    assertBNEq(
-      await deployedSeriesController.allowedExpirationsMap(date2),
       1,
       "map should be set",
     )
     assertBNEq(
-      await deployedSeriesController.allowedExpirationsMap(date3),
+      await deployedSeriesController.allowedExpirationsMap(date1),
       2,
+      "map should be set",
+    )
+    assertBNEq(
+      await deployedSeriesController.allowedExpirationsMap(date2),
+      3,
+      "map should be set",
+    )
+    assertBNEq(
+      await deployedSeriesController.allowedExpirationsMap(date3),
+      4,
       "map should be set",
     )
 
     assertBNEq(
-      await deployedSeriesController.allowedExpirationsList(0),
+      await deployedSeriesController.allowedExpirationsList(1),
       expiration,
       "list should be set",
     )
+
     assertBNEq(
-      await deployedSeriesController.allowedExpirationsList(1),
+      await deployedSeriesController.allowedExpirationsList(2),
+      date1,
+      "list should be set",
+    )
+    assertBNEq(
+      await deployedSeriesController.allowedExpirationsList(3),
       date2,
       "list should be set",
     )
     assertBNEq(
-      await deployedSeriesController.allowedExpirationsList(2),
+      await deployedSeriesController.allowedExpirationsList(4),
       date3,
       "list should be set",
     )

--- a/test/seriesController/seriesExpirations.ts
+++ b/test/seriesController/seriesExpirations.ts
@@ -1,0 +1,98 @@
+/* global artifacts contract it assert */
+import { expectRevert, expectEvent, BN } from "@openzeppelin/test-helpers"
+import { contract } from "hardhat"
+import { SeriesControllerInstance } from "../../typechain"
+
+import {
+  setupSingletonTestContracts,
+  getNextFriday8amUTCTimestamp,
+  assertBNEq,
+} from "../util"
+
+contract("Series Expirations", (accounts) => {
+  const aliceAccount = accounts[1]
+
+  // Set the expiration to 2 days from now
+  let expiration: number
+  let deployedSeriesController: SeriesControllerInstance
+
+  beforeEach(async () => {})
+
+  // Do a covered call - lock up bitcoin at a specific price
+  it("Validates Inputs on Expiration calls", async () => {
+    ;({ deployedSeriesController, expiration } =
+      await setupSingletonTestContracts())
+
+    // Verify ownership check
+    await expectRevert(
+      deployedSeriesController.updateAllowedExpirations([expiration], {
+        from: aliceAccount,
+      }),
+      "SeriesController: Caller is not the owner",
+    )
+
+    // Verify setting an expiration works from owner acct
+    await deployedSeriesController.updateAllowedExpirations([expiration])
+
+    // Verify adding the same one doesn't work since it is not greater than the last
+    await expectRevert(
+      deployedSeriesController.updateAllowedExpirations([expiration]),
+      "Order!",
+    )
+
+    // Verify adding a later non-aligned (not 8 AM) gets rejected
+    await expectRevert(
+      deployedSeriesController.updateAllowedExpirations([expiration + 500]),
+      "Nonaligned",
+    )
+
+    // Add a second and third one
+    const date2 = getNextFriday8amUTCTimestamp(expiration + 1000)
+    const date3 = getNextFriday8amUTCTimestamp(date2 + 1000)
+    let ret = await deployedSeriesController.updateAllowedExpirations([
+      date2,
+      date3,
+    ])
+
+    // Verify events
+    expectEvent(ret, "AllowedExpirationUpdated", {
+      newAllowedExpiration: new BN(date2),
+    })
+    expectEvent(ret, "AllowedExpirationUpdated", {
+      newAllowedExpiration: new BN(date3),
+    })
+
+    // Verify the list and map are updated
+    assertBNEq(
+      await deployedSeriesController.allowedExpirationsMap(expiration),
+      0,
+      "map should be set",
+    )
+    assertBNEq(
+      await deployedSeriesController.allowedExpirationsMap(date2),
+      1,
+      "map should be set",
+    )
+    assertBNEq(
+      await deployedSeriesController.allowedExpirationsMap(date3),
+      2,
+      "map should be set",
+    )
+
+    assertBNEq(
+      await deployedSeriesController.allowedExpirationsList(0),
+      expiration,
+      "list should be set",
+    )
+    assertBNEq(
+      await deployedSeriesController.allowedExpirationsList(1),
+      date2,
+      "list should be set",
+    )
+    assertBNEq(
+      await deployedSeriesController.allowedExpirationsList(2),
+      date3,
+      "list should be set",
+    )
+  })
+})

--- a/test/util.ts
+++ b/test/util.ts
@@ -453,6 +453,9 @@ export async function setupSingletonTestContracts(
       },
     )
 
+  // Add the expiration as valid to the series controller
+  await deployedSeriesController.updateAllowedExpirations([expiration])
+
   const deployedMockVolatilityOracle = await setUpMockVolatilityOracle(
     underlyingToken.address,
     priceToken.address,
@@ -695,6 +698,15 @@ export async function setupSeries({
   isPutOption = false,
   strikePrice = (10_000e8).toString(),
 }) {
+  // Verify the expiration is added
+  let expirationId: number
+  expirationId = await deployedSeriesController.allowedExpirationsMap(
+    expiration,
+  )
+  if (expirationId == 0) {
+    await deployedSeriesController.updateAllowedExpirations([expiration])
+  }
+
   const createSeriesResp = await deployedSeriesController.createSeries(
     {
       underlyingToken: underlyingToken.address,


### PR DESCRIPTION
This PR adds the requirement that expiration dates must be explicitly added by the admin before they can be used in a series.  The owner account must add the list of expiration dates before "createSeries" can be called with that expiration.

* Each expiration that is added is given an ExpirationID which is the index into the list of expirations (starts with ID = 1)
* Expirations are added to a mapping so that a given expiration date can be used to look up the corresponding Expiration ID
* Expiration dates must be aligned to the 8 AM daily or weekly date
* Expirations can only be added in ascending order

Other changes
* Minimized the error messages to get the contract size below the limit
* Moved the contract variables out into a separate contract to ensure upgrade compatibility going forward
* Added unit test for verifying the new logic of adding expirations