### PR TITLE
Refactor strikes management into SeriesDeployer

### DIFF
--- a/contracts/amm/IMinterAmm.sol
+++ b/contracts/amm/IMinterAmm.sol
@@ -50,4 +50,6 @@ interface IMinterAmm {
         returns (uint256);
 
     function updateAddressesProvider(address _addressesProvider) external;
+
+    function getCurrentUnderlyingPrice() external view returns (uint256);
 }

--- a/contracts/amm/MinterAmm.sol
+++ b/contracts/amm/MinterAmm.sol
@@ -628,7 +628,12 @@ contract MinterAmm is
     /// always with 8 decimals
     /// @dev For example, if underlying == WBTC and price == USDC, then this function will return
     /// 4500000000000 ($45_000 in human readable units)
-    function getCurrentUnderlyingPrice() private view returns (uint256) {
+    function getCurrentUnderlyingPrice()
+        public
+        view
+        override
+        returns (uint256)
+    {
         return
             IPriceOracle(addressesProvider.getPriceOracle()).getCurrentPrice(
                 address(underlyingToken),

--- a/contracts/series/ISeriesController.sol
+++ b/contracts/series/ISeriesController.sol
@@ -33,13 +33,6 @@ interface ISeriesController {
         uint256 strikePrice;
     }
 
-    /// @dev For a token, store the range for a strike price for the auto series creation feature
-    struct TokenStrikeRange {
-        uint256 min;
-        uint256 max;
-        uint256 increment;
-    }
-
     /// @notice All possible states a Series can be in with regard to its expiration date
     enum SeriesState {
         /**
@@ -141,14 +134,6 @@ interface ISeriesController {
 
     /** Emitted when the owner adds new allowed expirations */
     event AllowedExpirationUpdated(uint256 newAllowedExpiration);
-
-    /** Emitted when the owner updates the strike range for a specified asset */
-    event StrikeRangeUpdated(
-        address strikeUnderlyingToken,
-        uint256 min,
-        uint256 max,
-        uint256 increment
-    );
 
     ///////////////////// VIEW/PURE FUNCTIONS /////////////////////
 

--- a/contracts/series/SeriesControllerStorage.sol
+++ b/contracts/series/SeriesControllerStorage.sol
@@ -71,9 +71,6 @@ abstract contract SeriesControllerStorageV1 is ISeriesController {
 abstract contract SeriesControllerStorageV2 is SeriesControllerStorageV1 {
     IAddressesProvider public addressesProvider;
 
-    /// @dev For any token, track the ranges that are allowed for a strike price on the auto series creation feature
-    mapping(address => TokenStrikeRange) public allowedStrikeRanges;
-
     mapping(bytes32 => bool) public addedSeries;
 
     bytes32 public constant SERIES_DEPLOYER_ROLE =

--- a/contracts/series/SeriesDeployer.sol
+++ b/contracts/series/SeriesDeployer.sol
@@ -125,27 +125,32 @@ contract SeriesDeployer is
 
     /// @notice This function allows the owner address to update allowed strikes for the auto series creation feature
     /// @param strikeUnderlyingToken underlying asset token that options are written against
-    /// @param min minimum strike allowed
-    /// @param max maximum strike allowed
+    /// @param minPercent minimum strike allowed as percent of underlying price
+    /// @param maxPercent maximum strike allowed as percent of underlying price
     /// @param increment price increment allowed - e.g. if increment is 10, then 100 would be valid and 101 would not be (strike % increment == 0)
     /// @dev Only the owner address should be allowed to call this
     function updateAllowedTokenStrikeRanges(
         address strikeUnderlyingToken,
-        uint256 min,
-        uint256 max,
+        uint256 minPercent,
+        uint256 maxPercent,
         uint256 increment
     ) public onlyOwner {
         require(strikeUnderlyingToken != address(0x0), "!Token");
-        require(min < max, "!min/max");
+        require(minPercent < maxPercent, "!min/max");
         require(increment > 0, "!increment");
 
         allowedStrikeRanges[strikeUnderlyingToken] = TokenStrikeRange(
-            min,
-            max,
+            minPercent,
+            maxPercent,
             increment
         );
 
-        emit StrikeRangeUpdated(strikeUnderlyingToken, min, max, increment);
+        emit StrikeRangeUpdated(
+            strikeUnderlyingToken,
+            minPercent,
+            maxPercent,
+            increment
+        );
     }
 
     /// @dev This function allows any address to spin up a new series if it doesn't already exist and buy bTokens.

--- a/test/amm/minterAmmRemoveExpired.ts
+++ b/test/amm/minterAmmRemoveExpired.ts
@@ -40,14 +40,6 @@ contract("Minter AMM Remove expired series", (accounts) => {
       skipCreateSeries: true,
     }))
 
-    // Verify the strike is allowed
-    await deployedSeriesController.updateAllowedTokenStrikeRanges(
-      collateralToken.address,
-      new BN(STRIKE_PRICE).sub(new BN(1)),
-      new BN(STRIKE_PRICE).add(new BN(1)),
-      1,
-    )
-
     expirationLong = expiration + ONE_WEEK_DURATION
   })
 
@@ -100,14 +92,6 @@ contract("Minter AMM Remove expired series", (accounts) => {
 
   it("All series expired", async () => {
     const STRIKE_PRICE_2 = 15001 * 1e8
-
-    // Verify the strike is allowed
-    await deployedSeriesController.updateAllowedTokenStrikeRanges(
-      collateralToken.address,
-      new BN(STRIKE_PRICE).sub(new BN(1)),
-      new BN(STRIKE_PRICE_2).add(new BN(1)),
-      1,
-    )
 
     let ret = await deployedSeriesController.createSeries(
       {
@@ -162,14 +146,6 @@ contract("Minter AMM Remove expired series", (accounts) => {
     const STRIKE_PRICE_3 = 15002 * 1e8
     const STRIKE_PRICE_4 = 15003 * 1e8
     const STRIKE_PRICE_5 = 15003 * 1e8
-
-    // Verify the strike is allowed
-    await deployedSeriesController.updateAllowedTokenStrikeRanges(
-      collateralToken.address,
-      new BN(STRIKE_PRICE).sub(new BN(1)),
-      new BN(STRIKE_PRICE_5).add(new BN(1)),
-      1,
-    )
 
     let ret = await deployedSeriesController.createSeries(
       {
@@ -253,14 +229,6 @@ contract("Minter AMM Remove expired series", (accounts) => {
   // // // This is the edge case where i > openSeries.length
   it("1 open & 1 series expired(last one added to the open series)", async () => {
     const STRIKE_PRICE_2 = 15001 * 1e8
-
-    // Verify the strike is allowed
-    await deployedSeriesController.updateAllowedTokenStrikeRanges(
-      collateralToken.address,
-      new BN(STRIKE_PRICE).sub(new BN(1)),
-      new BN(STRIKE_PRICE_2).add(new BN(1)),
-      1,
-    )
 
     // Add the new expirations
     await deployedSeriesController.updateAllowedExpirations([expirationLong])
@@ -366,14 +334,6 @@ contract("Minter AMM Remove expired series", (accounts) => {
         seriesExpirations.push(isClosedSeries ? "closed" : "open")
 
         const strike = STRIKE_PRICE + k * 1e8
-
-        // Verify the strike is allowed
-        await deployedSeriesController.updateAllowedTokenStrikeRanges(
-          collateralToken.address,
-          new BN(strike).sub(new BN(1)),
-          new BN(strike).add(new BN(1)),
-          1,
-        )
 
         await deployedSeriesController.createSeries(
           {

--- a/test/governance/governanceScenario.ts
+++ b/test/governance/governanceScenario.ts
@@ -56,14 +56,6 @@ contract("Governance Verification", (accounts) => {
     // Allow the expiration
     await deployedSeriesController.allowedExpirationsMap(expiration)
 
-    // Allow the strike
-    await deployedSeriesController.updateAllowedTokenStrikeRanges(
-      underlyingToken.address,
-      new BN(STRIKE_PRICE).sub(new BN(1)),
-      new BN(STRIKE_PRICE).add(new BN(1)),
-      1,
-    )
-
     await time.increaseTo(expiration - ONE_WEEK_DURATION)
   })
 

--- a/test/seriesController/proxySeriesController.ts
+++ b/test/seriesController/proxySeriesController.ts
@@ -230,14 +230,6 @@ contract("Proxy Series Verification", (accounts) => {
       isPutOption,
     )
 
-    // Verify the strike is allowed
-    await deployedSeriesController.updateAllowedTokenStrikeRanges(
-      underlyingToken.address,
-      new BN(strikePrice).sub(new BN(1)),
-      new BN(additionalStrikePrice).add(new BN(1)),
-      1,
-    )
-
     const resp = await deployedSeriesController.createSeries(
       {
         underlyingToken: underlyingToken.address,

--- a/test/truffle-fixture.js
+++ b/test/truffle-fixture.js
@@ -1,6 +1,7 @@
 const SimpleToken = artifacts.require("SimpleToken")
 const SeriesController = artifacts.require("SeriesController")
 const SeriesVault = artifacts.require("SeriesVault")
+const SeriesDeployer = artifacts.require("SeriesDeployer")
 const AddressesProvider = artifacts.require("AddressesProvider")
 const ERC1155Controller = artifacts.require("ERC1155Controller")
 const MockPriceOracle = artifacts.require("MockPriceOracle")
@@ -18,6 +19,9 @@ module.exports = async () => {
 
   const seriesVault = await SeriesVault.new()
   SeriesVault.setAsDeployed(seriesVault)
+
+  const seriesDeployer = await SeriesDeployer.new()
+  SeriesDeployer.setAsDeployed(seriesDeployer)
 
   const erc1155Controller = await ERC1155Controller.new()
   ERC1155Controller.setAsDeployed(erc1155Controller)


### PR DESCRIPTION
* Allow SeriesController to manually create any strikes (owner only)
* Move strike range management into SeriesDeployer
* Use percentages of the underlying price for strike range
* Allow SeriesDeployer to be upgradable

This will allow the series management logic to be expanded in the future without reaching the limit of SeriesController code size