### PR TITLE
Limit number of series per expiration

### DIFF
--- a/contracts/series/SeriesDeployer.sol
+++ b/contracts/series/SeriesDeployer.sol
@@ -36,6 +36,8 @@ contract SeriesDeployer is
         uint256 increment
     );
 
+    event SeriesPerExpirationLimitUpdated(uint256 seriesPerExpirationLimit);
+
     /// @dev These contract variables, as well as the `nonReentrant` modifier further down below,
     /// are copied from OpenZeppelin's ReentrancyGuard contract. We chose to copy ReentrancyGuard instead of
     /// having SeriesController inherit it because we intend use this SeriesController contract to upgrade already-deployed
@@ -56,7 +58,7 @@ contract SeriesDeployer is
     mapping(address => TokenStrikeRange) public allowedStrikeRanges;
 
     /// @dev Max series for each expiration date
-    uint256 public constant SERIES_PER_EXPIRATION_LIMIT = 15;
+    uint256 public seriesPerExpirationLimit;
 
     /// @dev Counter of created series for each expiration date
     mapping(uint256 => uint256) public seriesPerExpirationCount;
@@ -95,6 +97,7 @@ contract SeriesDeployer is
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
 
         addressesProvider = _addressesProvider;
+        seriesPerExpirationLimit = 15;
     }
 
     /// @dev added since both base classes implement this function
@@ -127,6 +130,16 @@ contract SeriesDeployer is
     {
         require(_addressesProvider != address(0x0), "Invalid Address");
         addressesProvider = IAddressesProvider(_addressesProvider);
+    }
+
+    /// @dev Update limit of series per expiration date
+    function updateSeriesPerExpirationLimit(uint256 _seriesPerExpirationLimit)
+        public
+        onlyOwner
+    {
+        seriesPerExpirationLimit = _seriesPerExpirationLimit;
+
+        emit SeriesPerExpirationLimitUpdated(_seriesPerExpirationLimit);
     }
 
     /// @notice This function allows the owner address to update allowed strikes for the auto series creation feature
@@ -176,7 +189,7 @@ contract SeriesDeployer is
         seriesPerExpirationCount[_expirationDate] += 1;
         require(
             seriesPerExpirationCount[_expirationDate] <=
-                SERIES_PER_EXPIRATION_LIMIT,
+                seriesPerExpirationLimit,
             "!limit"
         );
 

--- a/contracts/series/SeriesDeployer.sol
+++ b/contracts/series/SeriesDeployer.sol
@@ -55,6 +55,12 @@ contract SeriesDeployer is
     /// @dev For any token, track the ranges that are allowed for a strike price on the auto series creation feature
     mapping(address => TokenStrikeRange) public allowedStrikeRanges;
 
+    /// @dev Max series for each expiration date
+    uint256 public constant SERIES_PER_EXPIRATION_LIMIT = 15;
+
+    /// @dev Counter of created series for each expiration date
+    mapping(uint256 => uint256) public seriesPerExpirationCount;
+
     /// @notice Check if the msg.sender is the privileged DEFAULT_ADMIN_ROLE holder
     modifier onlyOwner() {
         require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not Owner");
@@ -166,6 +172,14 @@ contract SeriesDeployer is
         uint256 _bTokenAmount,
         uint256 _collateralMaximum
     ) public nonReentrant returns (uint64) {
+        // Check limit per expiration
+        seriesPerExpirationCount[_expirationDate] += 1;
+        require(
+            seriesPerExpirationCount[_expirationDate] <=
+                SERIES_PER_EXPIRATION_LIMIT,
+            "!limit"
+        );
+
         // Save off the ammTokens
         ISeriesController.Tokens memory ammTokens = ISeriesController.Tokens(
             address(_existingAmm.underlyingToken()),

--- a/test/seriesController/autoCreateSeries.ts
+++ b/test/seriesController/autoCreateSeries.ts
@@ -445,4 +445,33 @@ contract("Auto Series Creation", (accounts) => {
       "Alice should not have spent all funds",
     )
   })
+
+  it("Allows to set limit of series per expiration", async () => {
+    ;({
+      underlyingToken,
+      collateralToken,
+      priceToken,
+      deployedSeriesController,
+      expiration,
+      deployedAmm,
+      deployedAddressesProvider,
+      deployedERC1155Controller,
+      deployedSeriesDeployer,
+    } = await setupAllTestContracts({
+      strikePrice: STRIKE_PRICE.toString(),
+      oraclePrice: UNDERLYING_PRICE,
+      annualizedVolatility: ANNUALIZED_VOLATILITY,
+    }))
+
+    let ret = await deployedSeriesDeployer.updateSeriesPerExpirationLimit(7)
+    expectEvent(ret, "SeriesPerExpirationLimitUpdated", {
+      seriesPerExpirationLimit: "7",
+    })
+
+    assertBNEq(
+      await deployedSeriesDeployer.seriesPerExpirationLimit(),
+      "7",
+      "seriesPerExpirationLimit should be correct",
+    )
+  })
 })

--- a/test/seriesController/autoCreateSeries.ts
+++ b/test/seriesController/autoCreateSeries.ts
@@ -300,6 +300,79 @@ contract("Auto Series Creation", (accounts) => {
     )
   })
 
+  it("Checks limit per expiration", async () => {
+    ;({
+      underlyingToken,
+      collateralToken,
+      priceToken,
+      deployedSeriesController,
+      expiration,
+      deployedAmm,
+      deployedAddressesProvider,
+      deployedERC1155Controller,
+      deployedSeriesDeployer,
+    } = await setupAllTestContracts({
+      strikePrice: STRIKE_PRICE.toString(),
+      oraclePrice: UNDERLYING_PRICE,
+      annualizedVolatility: ANNUALIZED_VOLATILITY,
+    }))
+
+    // Add a new expiration
+    const newExpiration = expiration + ONE_WEEK_DURATION
+    await deployedSeriesController.updateAllowedExpirations([newExpiration])
+
+    // Mint and approve tokens
+    await underlyingToken.mint(aliceAccount, 10e8)
+    await underlyingToken.approve(deployedSeriesDeployer.address, 10e8, {
+      from: aliceAccount,
+    })
+
+    // Get the index count
+    const beforeCount = await deployedSeriesController.latestIndex()
+
+    await deployedSeriesDeployer.updateAllowedTokenStrikeRanges(
+      underlyingToken.address,
+      50, // min 50% of underlying price
+      300, // max 300% of underlying price
+      1e8,
+    )
+
+    // Create 15 series
+    const promises = []
+    for (let i = 0; i < 15; i++) {
+      promises.push(
+        deployedSeriesDeployer.autoCreateSeriesAndBuy(
+          deployedAmm.address,
+          STRIKE_PRICE + i * 1e8,
+          newExpiration,
+          false,
+          1e4,
+          1e4,
+          {
+            from: aliceAccount,
+          },
+        ),
+      )
+    }
+    await Promise.all(promises)
+
+    // Try creating another one
+    await expectRevert(
+      deployedSeriesDeployer.autoCreateSeriesAndBuy(
+        deployedAmm.address,
+        STRIKE_PRICE + 15 * 1e8,
+        newExpiration,
+        false,
+        1e4,
+        1e4,
+        {
+          from: aliceAccount,
+        },
+      ),
+      "!limit",
+    )
+  })
+
   it("Allows series deployer to create", async () => {
     ;({
       underlyingToken,


### PR DESCRIPTION
Limit the number of series that can be created per expiration to 15