### PR TITLE
Configure direct buy manager

### DIFF
--- a/contracts/amm/MinterAmm.sol
+++ b/contracts/amm/MinterAmm.sol
@@ -711,7 +711,11 @@ contract MinterAmm is
         uint8 v, // Sig of signer wallet for Airswap
         bytes32 r, // Sig of signer wallet for Airswap
         bytes32 s // Sig of signer wallet for Airswap
-    ) external onlyOwner nonReentrant {
+    ) external nonReentrant {
+        require(
+            msg.sender == addressesProvider.getDirectBuyManager(),
+            "!manager"
+        );
         require(openSeries.contains(seriesId), "E13");
 
         address airswapLight = addressesProvider.getAirswapLight();

--- a/contracts/configuration/AddressesProvider.sol
+++ b/contracts/configuration/AddressesProvider.sol
@@ -24,6 +24,7 @@ contract AddressesProvider is
     bytes32 private constant VOLATILITY_ORACLE = "VOLATILITY_ORACLE";
     bytes32 private constant BLACKSCHOLES = "BLACKSCHOLES";
     bytes32 private constant AIRSWAP_LIGHT = "AIRSWAP_LIGHT";
+    bytes32 private constant DIRECT_BUY_MANAGER = "DIRECT_BUY_MANAGER";
 
     ///////////////////// MUTATING FUNCTIONS /////////////////////
 
@@ -138,5 +139,18 @@ contract AddressesProvider is
     function setAirswapLight(address airswapLight) external override onlyOwner {
         _addresses[AIRSWAP_LIGHT] = airswapLight;
         emit AirswapLightUpdated(airswapLight);
+    }
+
+    function getDirectBuyManager() external view override returns (address) {
+        return getAddress(DIRECT_BUY_MANAGER);
+    }
+
+    function setDirectBuyManager(address directBuyManager)
+        external
+        override
+        onlyOwner
+    {
+        _addresses[DIRECT_BUY_MANAGER] = directBuyManager;
+        emit DirectBuyManagerUpdated(directBuyManager);
     }
 }

--- a/contracts/configuration/IAddressesProvider.sol
+++ b/contracts/configuration/IAddressesProvider.sol
@@ -13,6 +13,7 @@ interface IAddressesProvider {
     event AmmDataProviderUpdated(address indexed newAddress);
     event SeriesControllerUpdated(address indexed newAddress);
     event LendingRateOracleUpdated(address indexed newAddress);
+    event DirectBuyManagerUpdated(address indexed newAddress);
     event ProxyCreated(bytes32 id, address indexed newAddress);
     event AddressSet(bytes32 id, address indexed newAddress, bool hasProxy);
     event VolatilityOracleUpdated(address indexed newAddress);
@@ -46,4 +47,8 @@ interface IAddressesProvider {
     function getAirswapLight() external view returns (address);
 
     function setAirswapLight(address airswapLight) external;
+
+    function getDirectBuyManager() external view returns (address);
+
+    function setDirectBuyManager(address directBuyManager) external;
 }

--- a/test/amm/minterAmmDirectBuy.ts
+++ b/test/amm/minterAmmDirectBuy.ts
@@ -20,7 +20,7 @@ const MinterAmmFeeBased: MinterAmmContract = artifacts.require("MinterAmm")
 const ERROR_MESSAGES = {
   B_TOKEN_BUY_SLIPPAGE: "Slippage exceeded",
   B_TOKEN_SELL_SLIPPAGE: "Slippage exceeded",
-  UNAUTHORIZED: "Ownable: caller is not the owner",
+  UNAUTHORIZED: "!manager",
 }
 
 let deployedERC1155Controller: ERC1155ControllerInstance
@@ -52,6 +52,8 @@ contract("AMM Direct Buy", (accounts) => {
       deployedLightAirswap,
       deployedAddressesProvider,
     } = await setupAllTestContracts({}))
+
+    await deployedAddressesProvider.setDirectBuyManager(ownerAccount)
   })
 
   it("Checks restrictions on direct buy", async () => {


### PR DESCRIPTION
Currently executing a direct buy order requires owner multisig signature. This enables setting a separate address to manage execution of direct buy orders.