### PR TITLE
Removed ERC1155Controller from AddressesProvider

### DIFF
--- a/contracts/configuration/AddressesProvider.sol
+++ b/contracts/configuration/AddressesProvider.sol
@@ -25,7 +25,6 @@ contract AddressesProvider is
     bytes32 private constant BLACKSCHOLES = "BLACKSCHOLES";
     bytes32 private constant AIRSWAP_LIGHT = "AIRSWAP_LIGHT";
     bytes32 private constant AMM_FACTORY = "AMM_FACTORY";
-    bytes32 private constant ERC1155_CONTROLLER = "ERC1155_CONTROLLER";
     bytes32 private constant DIRECT_BUY_MANAGER = "DIRECT_BUY_MANAGER";
 
     ///////////////////// MUTATING FUNCTIONS /////////////////////
@@ -150,19 +149,6 @@ contract AddressesProvider is
     function setAmmFactory(address ammFactory) external override onlyOwner {
         _addresses[AMM_FACTORY] = ammFactory;
         emit AmmFactoryUpdated(ammFactory);
-    }
-
-    function getErc1155Controller() external view override returns (address) {
-        return getAddress(ERC1155_CONTROLLER);
-    }
-
-    function setErc1155Controller(address erc1155Controller)
-        external
-        override
-        onlyOwner
-    {
-        _addresses[ERC1155_CONTROLLER] = erc1155Controller;
-        emit Erc1155ControllerUpdated(erc1155Controller);
     }
 
     function getDirectBuyManager() external view override returns (address) {

--- a/contracts/configuration/IAddressesProvider.sol
+++ b/contracts/configuration/IAddressesProvider.sol
@@ -54,10 +54,6 @@ interface IAddressesProvider {
 
     function setAmmFactory(address ammFactory) external;
 
-    function getErc1155Controller() external view returns (address);
-
-    function setErc1155Controller(address erc1155Controller) external;
-
     function getDirectBuyManager() external view returns (address);
 
     function setDirectBuyManager(address directBuyManager) external;

--- a/test/configuration/addresssesProvider.ts
+++ b/test/configuration/addresssesProvider.ts
@@ -110,27 +110,4 @@ contract("Address Provider Set/Get Verification", (accounts) => {
     const addr = await addrProvider.getAmmFactory()
     assert.equal(addr, randomAddress)
   })
-
-  it("Verifies Erc1155Controller Address", async () => {
-    const randomAddress = accounts[5]
-
-    const addrProvider = await deploy()
-    addrProvider.__AddressessProvider_init()
-
-    // Verify non admin can't set address
-    await expectRevert(
-      addrProvider.setErc1155Controller(randomAddress, { from: accounts[2] }),
-      "Ownable: caller is not the owner",
-    )
-
-    // Update the address
-    let ret = await addrProvider.setErc1155Controller(randomAddress)
-    expectEvent(ret, "Erc1155ControllerUpdated", {
-      newAddress: randomAddress,
-    })
-
-    // Get and verify
-    const addr = await addrProvider.getErc1155Controller()
-    assert.equal(addr, randomAddress)
-  })
 })

--- a/test/util.ts
+++ b/test/util.ts
@@ -396,10 +396,6 @@ export async function setupSingletonTestContracts(
     erc1155ControllerProxy.address,
   )
 
-  await deployedAddressesProvider.setErc1155Controller(
-    deployedERC1155Controller.address,
-  )
-
   // initialize the vault and erc1155 controller
   await deployedVault.__SeriesVault_init(deployedSeriesController.address)
   await deployedERC1155Controller.__ERC1155Controller_init(


### PR DESCRIPTION
`SeriesController` is tightly coupled with `ERC1155Controller`. As such it should always be retrieved as `seriesController.erc1155Controller()` instead of via the addresses provider.