### PR TITLE
Find earliest round for settlement price

### DIFF
--- a/contracts/series/IPriceOracle.sol
+++ b/contracts/series/IPriceOracle.sol
@@ -26,7 +26,8 @@ interface IPriceOracle {
     function setSettlementPriceForDate(
         address underlyingToken,
         address priceToken,
-        uint256 date
+        uint256 date,
+        uint80 roundId
     ) external;
 
     function get8amWeeklyOrDailyAligned(uint256 _timestamp)

--- a/contracts/series/PriceOracle.sol
+++ b/contracts/series/PriceOracle.sol
@@ -133,8 +133,15 @@ contract PriceOracle is IPriceOracle, OwnableUpgradeable, Proxiable {
                 targetPrice = uint256(answer);
             }
 
+            if (roundId == 0) break;
             roundId -= 1;
             (, answer, , roundTimestamp, ) = aggregator.getRoundData(roundId);
+
+            // handle incomplete round
+            if (roundTimestamp == 0) {
+                // set in order for the loop to continue
+                roundTimestamp = timestamp;
+            }
         }
 
         return (targetRoundId, targetPrice);

--- a/test/amm/minterAmmExpired.ts
+++ b/test/amm/minterAmmExpired.ts
@@ -424,6 +424,8 @@ contract("Minter AMM Expired", (accounts) => {
 
     // Move the block time into the exercise window
     await time.increase(ONE_WEEK_DURATION)
+    // Set oracle price round again for the new timestamp
+    await deployedMockPriceOracle.setLatestAnswer(25_000 * 10 ** 8)
 
     // Alice exercises her options
     // 2,000(amount) * (25,000(price) - 20,000(strike)) / 25,000(price) = 400 collateral
@@ -732,6 +734,7 @@ contract("Minter AMM Expired", (accounts) => {
 
     // Move the block time into the future so the contract is expired
     await time.increaseTo(expiration)
+    await deployedMockPriceOracle.setLatestAnswer(UNDERLYING_PRICE)
 
     // Make sure series is expired
     assertBNEq(
@@ -875,6 +878,7 @@ contract("Minter AMM Expired", (accounts) => {
 
     // Move the block time into the future so the contract is expired
     await time.increaseTo(expiration)
+    await deployedMockPriceOracle.setLatestAnswer(UNDERLYING_PRICE)
 
     // Make sure series is expired
     assertBNEq(

--- a/test/amm/minterAmmGas.ts
+++ b/test/amm/minterAmmGas.ts
@@ -3,6 +3,7 @@ import { time, BN } from "@openzeppelin/test-helpers"
 import { artifacts, contract, assert } from "hardhat"
 import {
   PriceOracleInstance,
+  MockPriceOracleInstance,
   SimpleTokenContract,
   SimpleTokenInstance,
   MinterAmmInstance,
@@ -24,6 +25,7 @@ let deployedSeriesController: SeriesControllerInstance
 let deployedERC1155Controller: ERC1155ControllerInstance
 let deployedAmm: MinterAmmInstance
 let deployedPriceOracle: PriceOracleInstance
+let deployedMockPriceOracle: MockPriceOracleInstance
 
 let underlyingToken: SimpleTokenInstance
 let priceToken: SimpleTokenInstance
@@ -55,6 +57,7 @@ contract("Minter AMM Gas Measurement", (accounts) => {
       deployedSeriesController,
       deployedERC1155Controller,
       deployedPriceOracle,
+      deployedMockPriceOracle,
       expiration,
     } = await setupAllTestContracts({
       strikePrice: STRIKE_PRICE.toString(),
@@ -229,6 +232,7 @@ contract("Minter AMM Gas Measurement", (accounts) => {
     // Move the block time into the future so exactly numExpiredSeries number
     // of series are expired
     await time.increaseTo(expiration + numExpiredSeries * oneWeek + 60)
+    await deployedMockPriceOracle.setLatestAnswer(BTC_ORACLE_PRICE)
 
     // now that we advanced forward to the expiration date, we can set the Series' matching
     // settlement price on the PriceOracle

--- a/test/amm/wTokenVault.ts
+++ b/test/amm/wTokenVault.ts
@@ -619,6 +619,7 @@ contract("wToken Vault", (accounts) => {
 
       // Expiration 1
       await mineBlock(expiration)
+      await deployedMockPriceOracle.setLatestAnswer(13_000e8)
 
       // Check redeemable collateral
       assertBNEq(
@@ -716,6 +717,7 @@ contract("wToken Vault", (accounts) => {
 
       // Expiration 1
       await mineBlock(expiration2)
+      await deployedMockPriceOracle.setLatestAnswer(16_000e8)
 
       // LP1 withdraws all capital
       await setNextBlockTimestamp(expiration2 + 10)

--- a/test/chainlink-keepers/priceOracleKeeper.ts
+++ b/test/chainlink-keepers/priceOracleKeeper.ts
@@ -28,7 +28,7 @@ let priceToken: SimpleTokenInstance
 
 const underlyingToken2Address = "0x1574e9cb330def04be5a639f57dd52037a2ad206"
 
-contract("AMM Call Verification", (accounts) => {
+contract("Price Oracle Keeper", (accounts) => {
   const ownerAccount = accounts[0]
   const aliceAccount = accounts[1]
   const bobAccount = accounts[2]
@@ -71,6 +71,8 @@ contract("AMM Call Verification", (accounts) => {
 
     // increase time to next week
     await time.increaseTo(previousSettlementTime.add(new BN(60 * 60 * 24 * 7)))
+    await deployedMockPriceOracle.setLatestAnswer(3000)
+    await deployedMockPriceOracle2.setLatestAnswer(100)
 
     const currentSettlementTime =
       await deployedPriceOracle.get8amWeeklyOrDailyAligned(await time.latest())
@@ -91,7 +93,7 @@ contract("AMM Call Verification", (accounts) => {
     // perform upkeep
     await priceOracleKeeper.performUpkeep("0x0")
 
-    // Ceck that settlement price is set after the upkeep
+    // Check that settlement price is set after the upkeep
     assertBNEq(
       (
         await deployedPriceOracle.getSettlementPrice(

--- a/test/seriesController/cashSettlement.ts
+++ b/test/seriesController/cashSettlement.ts
@@ -411,6 +411,8 @@ contract("Cash Settlement", (accounts) => {
 
     await time.increaseTo(afterExpiry)
 
+    await deployedMockPriceOracle.setLatestAnswer(collateralPrice)
+
     claimCalc = await deployedSeriesController.getClaimAmount(
       seriesId,
       mintAmount,
@@ -427,6 +429,7 @@ contract("Cash Settlement", (accounts) => {
 
     // set the settlement price, and we should see the Series uses that price instead of the current price
     const newCurrentPrice = 25_000 * 10 ** wBTCDecimals
+    await deployedMockPriceOracle.reset()
     await deployedMockPriceOracle.setLatestAnswer(newCurrentPrice)
     await deployedPriceOracle.setSettlementPrice(
       underlyingToken.address,

--- a/test/seriesController/seriesScenarios.ts
+++ b/test/seriesController/seriesScenarios.ts
@@ -53,8 +53,10 @@ contract("Series Scenarios", (accounts) => {
     // Give Alice the collateral
     await collateralToken.mint(aliceAccount, mintAmount)
 
+    // Erase all previous rounds
+    await deployedMockPriceOracle.reset()
     const oraclePrice = 22_000 * 10 ** 8 // 22k
-    await deployedMockPriceOracle.setLatestAnswer(oraclePrice)
+    await deployedMockPriceOracle.addRound(oraclePrice, expiration, expiration)
 
     const { seriesId } = await setupSeries({
       deployedSeriesController,

--- a/test/util.ts
+++ b/test/util.ts
@@ -442,6 +442,14 @@ export async function setupSingletonTestContracts(
   let expiration: number = getNextFriday8amUTCTimestamp(
     (await now()) + ONE_WEEK_DURATION,
   )
+
+  // Set settlement price on expiration
+  await deployedMockPriceOracle.addRound(
+    oraclePrice,
+    expiration + 10,
+    expiration + 10,
+  )
+
   const deployedPriceOracle = await setupPriceOracle(
     underlyingToken.address,
     priceToken.address,


### PR DESCRIPTION
Previously the settlement oracle used the latest chainlink price as settlement price. This made the settlement price sensitive to how soon the `setSettlementPrice` transaction is mined. This PR makes it search for the earliest oracle round after the settlement date instead. 