### PR TITLE
Revert 5.7 changes

### DIFF
--- a/contracts/amm/AmmFactory.sol
+++ b/contracts/amm/AmmFactory.sol
@@ -42,8 +42,10 @@ contract AmmFactory is OwnableUpgradeable, Proxiable {
     /// @notice Emitted when the owner updates the token implementation address
     event TokenImplementationUpdated(address newAddress);
 
-    /// @notice Setup the state variables for an AmmFactory
-    function initialize(
+    /**
+     * Initialization function that only allows itself to be called once
+     */
+    function __AmmFactory_init(
         address _ammImplementation,
         address _tokenImplementation,
         ISeriesController _seriesController,

--- a/contracts/configuration/AddressesProvider.sol
+++ b/contracts/configuration/AddressesProvider.sol
@@ -32,7 +32,7 @@ contract AddressesProvider is
     ///////////////////// MUTATING FUNCTIONS /////////////////////
 
     /// @notice Perform inherited contracts' initializations
-    function initialize() external initializer {
+    function __AddressessProvider_init() external initializer {
         __Ownable_init_unchained();
     }
 

--- a/contracts/series/SeriesController.sol
+++ b/contracts/series/SeriesController.sol
@@ -609,7 +609,7 @@ contract SeriesController is
     /// @param _addressesProvider The PriceOracle used for fetching prices for Series
     /// @param _vault The SeriesVault contract that will be used to store all of this SeriesController's tokens
     /// @param _fees The various fees to charge on executing certain SeriesController functions
-    function initialize(
+    function __SeriesController_init(
         address _addressesProvider,
         address _vault,
         address _erc1155Controller,

--- a/contracts/series/SeriesDeployer.sol
+++ b/contracts/series/SeriesDeployer.sol
@@ -91,7 +91,7 @@ contract SeriesDeployer is
         _status = _NOT_ENTERED;
     }
 
-    function initialize(IAddressesProvider _addressesProvider)
+    function __SeriesDeployer_init(IAddressesProvider _addressesProvider)
         external
         initializer
     {

--- a/contracts/series/SeriesVault.sol
+++ b/contracts/series/SeriesVault.sol
@@ -52,7 +52,10 @@ contract SeriesVault is
     ///////////////////// MUTATING FUNCTIONS /////////////////////
 
     /// @notice Perform inherited contracts' initializations
-    function initialize(address _seriesController) external initializer {
+    function __SeriesVault_init(address _seriesController)
+        external
+        initializer
+    {
         __ERC1155Holder_init();
         __Ownable_init_unchained();
 

--- a/scripts/lib/deploy_singleton_contracts.ts
+++ b/scripts/lib/deploy_singleton_contracts.ts
@@ -250,13 +250,13 @@ export async function deploySingletonContracts(
   )
 
   // now that we've deployed, let's initialize them in the correct order
-  await erc1155Controller.initialize(
+  await erc1155Controller.__ERC1155Controller_init(
     "https://erc1155.sirenmarkets.com/v2/{id}.json",
     seriesController.address,
   )
   console.log("initialized ERC1155Controller")
 
-  await (await seriesVault.initialize(seriesController.address)).wait()
+  await (await seriesVault.__SeriesVault_init(seriesController.address)).wait()
   console.log("initialized SeriesVault")
 
   // wait a bit for the node provider's chain state to update so the following does not fail
@@ -275,6 +275,7 @@ export async function deploySingletonContracts(
   //     },
   //   )
   // ).wait()
+
   console.log("initialized SeriesController")
 
   await (await priceOracle.initialize(dateOffset)).wait()

--- a/test/amm/minterAmmUpgradeable.ts
+++ b/test/amm/minterAmmUpgradeable.ts
@@ -139,7 +139,7 @@ contract("AMM Upgradeability", (accounts) => {
       proxyAddressesProvider.address,
     )
 
-    deployedAddressesProvider2.initialize()
+    deployedAddressesProvider2.__AddressessProvider_init()
 
     let ret = await deployedAmm.updateAddressesProvider(
       deployedAddressesProvider2.address,

--- a/test/configuration/addresssesProvider.ts
+++ b/test/configuration/addresssesProvider.ts
@@ -76,7 +76,7 @@ contract("Address Provider Set/Get Verification", (accounts) => {
       proxyAddressesProvider.address,
     )
 
-    deployedAddressesProvider2.initialize()
+    deployedAddressesProvider2.__AddressessProvider_init()
 
     let getAddress = await deployedAddressesProvider2.getSeriesController()
 
@@ -92,7 +92,7 @@ contract("Address Provider Set/Get Verification", (accounts) => {
     const randomAddress = accounts[5]
 
     const addrProvider = await deploy()
-    addrProvider.initialize()
+    addrProvider.__AddressessProvider_init()
 
     // Verify non admin can't set address
     await expectRevert(

--- a/test/seriesController/proxySeriesController.ts
+++ b/test/seriesController/proxySeriesController.ts
@@ -99,7 +99,7 @@ contract("Proxy Series Verification", (accounts) => {
 
     // cannot initialize twice
     await expectRevert(
-      deployedSeriesController.initialize(
+      deployedSeriesController.__SeriesController_init(
         deployedAddressesProvider.address,
         deployedVault.address,
         deployedERC1155Controller.address,

--- a/test/seriesVault/proxySeriesVault.ts
+++ b/test/seriesVault/proxySeriesVault.ts
@@ -16,7 +16,7 @@ contract("Proxy Vault Verification", (accounts) => {
     const { deployedSeriesController, deployedVault } =
       await setupAllTestContracts()
     await expectRevert(
-      deployedVault.initialize(deployedSeriesController.address),
+      deployedVault.__SeriesVault_init(deployedSeriesController.address),
       "Initializable: contract is already initialized",
     )
   })
@@ -58,7 +58,7 @@ contract("Proxy Vault Verification", (accounts) => {
       "SeriesVault: Sender must be the seriesController",
     )
 
-    // since setupAllTestContracts calls SeriesController.initialize, which calls
+    // since setupAllTestContracts calls SeriesController.__SeriesController_init, which calls
     // setERC1155ApprovalForController, we should see that the allowance has been set correctly
     assert.strictEqual(
       await deployedERC1155Controller.isApprovedForAll(

--- a/test/util.ts
+++ b/test/util.ts
@@ -519,7 +519,7 @@ export async function setupSingletonTestContracts(
   const ammFactoryProxy = await Proxy.new(ammFactoryLogic.address)
   const deployedAmmFactory = await AmmFactory.at(ammFactoryProxy.address)
 
-  await deployedAmmFactory.initialize(
+  await deployedAmmFactory.__AmmFactory_init(
     ammLogic.address,
     erc20Logic.address,
     deployedSeriesController.address,

--- a/test/util.ts
+++ b/test/util.ts
@@ -378,7 +378,7 @@ export async function setupSingletonTestContracts(
     proxyAddressesProvider.address,
   )
 
-  deployedAddressesProvider.initialize()
+  deployedAddressesProvider.__AddressessProvider_init()
 
   const proxyContract = await Proxy.new(seriesControllerLogic.address)
   const deployedSeriesController = await SeriesController.at(
@@ -413,7 +413,7 @@ export async function setupSingletonTestContracts(
   )
 
   // initialize the vault and erc1155 controller
-  await deployedVault.initialize(deployedSeriesController.address)
+  await deployedVault.__SeriesVault_init(deployedSeriesController.address)
   await deployedERC1155Controller.__ERC1155Controller_init(
     erc1155URI,
     deployedSeriesController.address,
@@ -459,17 +459,18 @@ export async function setupSingletonTestContracts(
     deployedAmmDataProvider.address,
   )
 
-  const controllerInitResp = await deployedSeriesController.initialize(
-    deployedAddressesProvider.address,
-    deployedVault.address,
-    deployedERC1155Controller.address,
-    {
-      feeReceiver: feeReceiver,
-      exerciseFeeBasisPoints: exerciseFee,
-      closeFeeBasisPoints: closeFee,
-      claimFeeBasisPoints: claimFee,
-    },
-  )
+  const controllerInitResp =
+    await deployedSeriesController.__SeriesController_init(
+      deployedAddressesProvider.address,
+      deployedVault.address,
+      deployedERC1155Controller.address,
+      {
+        feeReceiver: feeReceiver,
+        exerciseFeeBasisPoints: exerciseFee,
+        closeFeeBasisPoints: closeFee,
+        claimFeeBasisPoints: claimFee,
+      },
+    )
 
   // Add the expiration as valid to the series controller
   await deployedSeriesController.updateAllowedExpirations([expiration])
@@ -479,7 +480,9 @@ export async function setupSingletonTestContracts(
   const deployedSeriesDeployer = await SeriesDeployer.at(
     proxySeriesDeployer.address,
   )
-  await deployedSeriesDeployer.initialize(deployedAddressesProvider.address)
+  await deployedSeriesDeployer.__SeriesDeployer_init(
+    deployedAddressesProvider.address,
+  )
 
   // Add the series deployer contract to the allowed creators list
   await deployedSeriesController.grantRole(


### PR DESCRIPTION
We decided to revert this change. The reason is that using `initialize` instead of a unique contract-specific name creates a risk of colliding with `initialize` method on inherited contract, for example this happens with the ERC1155 contract.