### PR TITLE
pricing for non existent series

### DIFF
--- a/contracts/amm/AmmDataProvider.sol
+++ b/contracts/amm/AmmDataProvider.sol
@@ -65,9 +65,9 @@ contract AmmDataProvider is IAmmDataProvider {
         uint256 collateralTokenBalance,
         uint256 bTokenPrice
     ) public view override returns (uint256, uint256) {
-        //We commenting this out, but in the furute for perpetuals we will need it
         //We set wTokenBalance = 0
-        //
+        uint256 wTokenBalance = 0;
+        //We commenting this out, but in the furute for perpetuals we will need it
         /*
         uint256 wTokenBalance = erc1155Controller.balanceOf(
             ammAddress,
@@ -88,7 +88,8 @@ contract AmmDataProvider is IAmmDataProvider {
         // For put convert token balances into collateral locked in them
         uint256 lockedUnderlyingValue = 1e18;
         if (series.isPutOption) {
-            // TODO: this logic causes the underlying price to be fetched twice from the oracle. Can be optimized.
+            // TODO: this logic causes the underlying price to be fetched twice from the oracle.
+            //Can be optimized.
             lockedUnderlyingValue =
                 (lockedUnderlyingValue * series.strikePrice) /
                 IPriceOracle(addressesProvider.getPriceOracle())
@@ -100,7 +101,7 @@ contract AmmDataProvider is IAmmDataProvider {
 
         // Max amount of tokens we can get by adding current balance plus what can be minted from collateral
         uint256 bTokenBalanceMax = bTokenBalance + collateralTokenBalance;
-        uint256 wTokenBalanceMax = 0 + collateralTokenBalance; //We set wTokenBalance = 0
+        uint256 wTokenBalanceMax = wTokenBalance + collateralTokenBalance;
 
         uint256 wTokenPrice = lockedUnderlyingValue - bTokenPrice;
 
@@ -553,6 +554,16 @@ contract AmmDataProvider is IAmmDataProvider {
         return collateralWithoutFees + tradeFee;
     }
 
+    /// @notice Calculate premium (i.e. the option price) to buy bTokenAmount bTokens for a
+    ///  new Series
+    /// @notice The premium depends on the amount of collateral token in the pool, the reserves
+    /// of bToken and wToken in the pool, and the current series price of the underlying
+    /// @param series The new Series to buy bToken on
+    /// @param bTokenAmount The amount of bToken to buy, which uses the same decimals as
+    /// the underlying ERC20 token
+    /// @param ammAddress adress of the amm
+    /// @return The amount of collateral token necessary to buy bTokenAmount worth of bTokens
+    /// NOTE: This returns the collateral + fee amount
     function bTokenGetCollateralInForNewSeries(
         ISeriesController.Series memory series,
         address ammAddress,

--- a/contracts/amm/AmmDataProvider.sol
+++ b/contracts/amm/AmmDataProvider.sol
@@ -530,7 +530,6 @@ contract AmmDataProvider is IAmmDataProvider {
     /// @return The amount of collateral token necessary to buy bTokenAmount worth of bTokens
     /// NOTE: This returns the collateral + fee amount
     function bTokenGetCollateralInView(
-        //bTokenGetCollateralInForNewSeriesView
         address ammAddress,
         uint64 seriesId,
         uint256 bTokenAmount
@@ -560,6 +559,18 @@ contract AmmDataProvider is IAmmDataProvider {
         uint256 bTokenAmount
     ) external view override returns (uint256) {
         IMinterAmm amm = IMinterAmm(ammAddress);
+        require(
+            address(amm.priceToken()) == series.tokens.priceToken,
+            "!priceToken"
+        );
+        require(
+            address(amm.collateralToken()) == series.tokens.collateralToken,
+            "!collateralToken"
+        );
+        require(
+            address(amm.underlyingToken()) == series.tokens.underlyingToken,
+            "!underlyingToken"
+        );
 
         uint256 collateralWithoutFees = bTokenGetCollateralIn(
             series,

--- a/contracts/amm/IAmmDataProvider.sol
+++ b/contracts/amm/IAmmDataProvider.sol
@@ -43,14 +43,8 @@ interface IAmmDataProvider {
         uint256 impliedVolatility
     ) external view returns (uint256);
 
-    function getPriceForSeries(uint64 seriesId, uint256 annualVolatility)
-        external
-        view
-        returns (uint256);
-
-    function getPriceForNewSeries(
+    function getPriceForSeries(
         ISeriesController.Series memory series,
-        uint256 underlyingPrice,
         uint256 annualVolatility
     ) external view returns (uint256);
 
@@ -75,6 +69,12 @@ interface IAmmDataProvider {
     function bTokenGetCollateralInView(
         address ammAddress,
         uint64 seriesId,
+        uint256 bTokenAmount
+    ) external view returns (uint256);
+
+    function bTokenGetCollateralInForNewSeries(
+        ISeriesController.Series memory series,
+        address ammAddress,
         uint256 bTokenAmount
     ) external view returns (uint256);
 

--- a/contracts/amm/IAmmDataProvider.sol
+++ b/contracts/amm/IAmmDataProvider.sol
@@ -2,16 +2,18 @@
 
 pragma solidity 0.8.0;
 
+import "../series/ISeriesController.sol";
+
 interface IAmmDataProvider {
     function getVirtualReserves(
-        uint64 seriesId,
+        ISeriesController.Series memory series,
         address ammAddress,
         uint256 collateralTokenBalance,
         uint256 bTokenPrice
     ) external view returns (uint256, uint256);
 
     function bTokenGetCollateralIn(
-        uint64 seriesId,
+        ISeriesController.Series memory series,
         address ammAddress,
         uint256 bTokenAmount,
         uint256 collateralTokenBalance,
@@ -45,6 +47,12 @@ interface IAmmDataProvider {
         external
         view
         returns (uint256);
+
+    function getPriceForNewSeries(
+        ISeriesController.Series memory series,
+        uint256 underlyingPrice,
+        uint256 annualVolatility
+    ) external view returns (uint256);
 
     function getTotalPoolValue(
         bool includeUnclaimed,

--- a/contracts/amm/MinterAmm.sol
+++ b/contracts/amm/MinterAmm.sol
@@ -794,10 +794,13 @@ contract MinterAmm is
 
         // Mint required number of bTokens for the direct buy (if required)
         if (bTokenBalance < senderAmount) {
+            ISeriesController.Series memory series = seriesController.series(
+                seriesId
+            );
             // Approve the collateral to mint bTokenAmount of new options
             uint256 bTokenCollateralAmount = seriesController
                 .getCollateralPerOptionToken(
-                    seriesId,
+                    series,
                     senderAmount - bTokenBalance
                 );
 
@@ -864,6 +867,9 @@ contract MinterAmm is
             "E22" // Series has expired
         );
         uint256 collateralAmount;
+        ISeriesController.Series memory series = seriesController.series(
+            seriesId
+        );
         {
             uint256 underlyingPrice = getCurrentUnderlyingPrice();
             (uint256 price, uint256 vega) = calculatePriceAndVega(
@@ -873,7 +879,7 @@ contract MinterAmm is
             require(price > 0, "E17");
 
             collateralAmount = getAmmDataProvider().bTokenGetCollateralIn(
-                seriesId,
+                series,
                 address(this),
                 bTokenAmount,
                 collateralBalance(),
@@ -882,7 +888,7 @@ contract MinterAmm is
             require(
                 collateralAmount * 1e18 >=
                     seriesController.getCollateralPerUnderlying(
-                        seriesId,
+                        series,
                         price * bTokenAmount,
                         underlyingPrice
                     ),
@@ -895,7 +901,7 @@ contract MinterAmm is
                     priceImpact =
                         (collateralAmount * 1e26) /
                         seriesController.getCollateralPerUnderlying(
-                            seriesId,
+                            series,
                             bTokenAmount,
                             1e8
                         ) /
@@ -939,7 +945,7 @@ contract MinterAmm is
 
         // Approve the collateral to mint bTokenAmount of new options
         uint256 bTokenCollateralAmount = seriesController
-            .getCollateralPerOptionToken(seriesId, bTokenAmount);
+            .getCollateralPerOptionToken(series, bTokenAmount);
 
         collateralToken.approve(
             address(seriesController),
@@ -990,6 +996,9 @@ contract MinterAmm is
             "E22" // Series has expired
         );
         uint256 collateralAmount;
+        ISeriesController.Series memory series = seriesController.series(
+            seriesId
+        );
         {
             uint256 underlyingPrice = getCurrentUnderlyingPrice();
             (uint256 price, uint256 vega) = calculatePriceAndVega(
@@ -1005,10 +1014,11 @@ contract MinterAmm is
                 price,
                 true
             );
+
             require(
                 collateralAmount * 1e18 <=
                     seriesController.getCollateralPerUnderlying(
-                        seriesId,
+                        series,
                         price * bTokenAmount,
                         underlyingPrice
                     ),
@@ -1022,7 +1032,7 @@ contract MinterAmm is
                         price -
                         (collateralAmount * 1e26) /
                         seriesController.getCollateralPerUnderlying(
-                            seriesId,
+                            series,
                             bTokenAmount,
                             1e8
                         ) /

--- a/contracts/amm/MinterAmm.sol
+++ b/contracts/amm/MinterAmm.sol
@@ -712,10 +712,12 @@ contract MinterAmm is
     /// representing the price as a fraction of 1 collateral token unit
     function getPriceForSeries(uint64 seriesId) public view returns (uint256) {
         require(openSeries.contains(seriesId), "E13");
-
+        ISeriesController.Series memory series = seriesController.series(
+            seriesId
+        );
         return
             getAmmDataProvider().getPriceForSeries(
-                seriesId,
+                series,
                 getVolatility(seriesId)
             );
     }

--- a/contracts/amm/WTokenVault.sol
+++ b/contracts/amm/WTokenVault.sol
@@ -141,7 +141,7 @@ contract WTokenVault is OwnableUpgradeable, Proxiable, IWTokenVault {
                 uint256 valuePerToken;
                 if (series.isPutOption) {
                     valuePerToken = seriesController.getCollateralPerUnderlying(
-                            seriesId,
+                            series,
                             (series.strikePrice * 1e18) /
                                 vars.underlyingPrice -
                                 bPrice,
@@ -339,7 +339,7 @@ contract WTokenVault is OwnableUpgradeable, Proxiable, IWTokenVault {
                 uint256 valuePerToken;
                 if (series.isPutOption) {
                     valuePerToken = seriesController.getCollateralPerUnderlying(
-                            seriesId,
+                            series,
                             (series.strikePrice * 1e18) /
                                 vars.underlyingPrice -
                                 bPrice,

--- a/contracts/amm/WTokenVault.sol
+++ b/contracts/amm/WTokenVault.sol
@@ -136,7 +136,7 @@ contract WTokenVault is OwnableUpgradeable, Proxiable, IWTokenVault {
 
                 uint256 bPrice = IAmmDataProvider(
                     addressesProvider.getAmmDataProvider()
-                ).getPriceForSeries(seriesId, vars.volatility);
+                ).getPriceForSeries(series, vars.volatility);
 
                 uint256 valuePerToken;
                 if (series.isPutOption) {
@@ -334,7 +334,7 @@ contract WTokenVault is OwnableUpgradeable, Proxiable, IWTokenVault {
 
                 uint256 bPrice = IAmmDataProvider(
                     addressesProvider.getAmmDataProvider()
-                ).getPriceForSeries(seriesId, vars.volatility);
+                ).getPriceForSeries(series, vars.volatility);
 
                 uint256 valuePerToken;
                 if (series.isPutOption) {

--- a/contracts/series/ISeriesController.sol
+++ b/contracts/series/ISeriesController.sol
@@ -209,12 +209,12 @@ interface ISeriesController {
     function isPutOption(uint64 _seriesId) external view returns (bool);
 
     function getCollateralPerOptionToken(
-        uint64 _seriesId,
+        ISeriesController.Series memory _currentSeries,
         uint256 _optionTokenAmount
     ) external view returns (uint256);
 
     function getCollateralPerUnderlying(
-        uint64 _seriesId,
+        ISeriesController.Series memory _currentSeries,
         uint256 _underlyingAmount,
         uint256 _price
     ) external view returns (uint256);

--- a/contracts/series/SeriesController.sol
+++ b/contracts/series/SeriesController.sol
@@ -177,19 +177,19 @@ contract SeriesController is
             if (settlementPrice >= currentSeries.strikePrice) {
                 // OTM
                 writerShare = getCollateralPerOptionToken(
-                    _seriesId,
+                    currentSeries,
                     _optionTokenAmount
                 );
                 buyerShare = 0;
             } else {
                 // ITM
                 writerShare = getCollateralPerUnderlying(
-                    _seriesId,
+                    currentSeries,
                     _optionTokenAmount,
                     settlementPrice
                 );
                 buyerShare = getCollateralPerUnderlying(
-                    _seriesId,
+                    currentSeries,
                     _optionTokenAmount,
                     currentSeries.strikePrice - settlementPrice
                 );
@@ -411,7 +411,7 @@ contract SeriesController is
     }
 
     /// @notice Given a series ID and an amount of bToken/wToken, return the amount of collateral token received when it's exercised
-    /// @param _seriesId The Series ID
+    /// @param _currentSeries The Series
     /// @param _optionTokenAmount The amount of bToken/wToken
     /// @return The amount of collateral token received when exercising this amount of option token
     function getCollateralPerOptionToken(
@@ -428,7 +428,7 @@ contract SeriesController is
 
     /// @dev Given a Series and an amount of underlying, return the amount of collateral adjusted for decimals
     /// @dev In almost every callsite of this function the price is equal to the strike price, except in Series.getSettlementAmounts where we use the settlementPrice
-    /// @param _seriesId The Series ID
+    /// @param _currentSeries The Series
     /// @param _underlyingAmount The amount of underlying
     /// @param _price The price of the collateral token in units of price token
     /// @return The amount of collateral
@@ -892,9 +892,9 @@ contract SeriesController is
             optionTokenAmounts,
             data
         );
-
+        ISeriesController.Series memory series = allSeries[_seriesId];
         uint256 collateralAmount = getCollateralPerOptionToken(
-            _seriesId,
+            series,
             _optionTokenAmount
         );
 
@@ -1088,9 +1088,9 @@ contract SeriesController is
             optionTokenIds,
             optionTokenAmounts
         );
-
+        ISeriesController.Series memory series = allSeries[_seriesId];
         uint256 collateralAmount = getCollateralPerOptionToken(
-            _seriesId,
+            series,
             _optionTokenAmount
         );
 

--- a/contracts/series/SeriesController.sol
+++ b/contracts/series/SeriesController.sol
@@ -415,14 +415,14 @@ contract SeriesController is
     /// @param _optionTokenAmount The amount of bToken/wToken
     /// @return The amount of collateral token received when exercising this amount of option token
     function getCollateralPerOptionToken(
-        uint64 _seriesId,
+        ISeriesController.Series memory _currentSeries,
         uint256 _optionTokenAmount
     ) public view override returns (uint256) {
         return
             getCollateralPerUnderlying(
-                _seriesId,
+                _currentSeries,
                 _optionTokenAmount,
-                allSeries[_seriesId].strikePrice
+                _currentSeries.strikePrice
             );
     }
 
@@ -433,14 +433,12 @@ contract SeriesController is
     /// @param _price The price of the collateral token in units of price token
     /// @return The amount of collateral
     function getCollateralPerUnderlying(
-        uint64 _seriesId,
+        ISeriesController.Series memory _currentSeries,
         uint256 _underlyingAmount,
         uint256 _price
     ) public view override returns (uint256) {
-        Series memory currentSeries = allSeries[_seriesId];
-
         // is it a call option?
-        if (!currentSeries.isPutOption) {
+        if (!_currentSeries.isPutOption) {
             // for call options this conversion is simple, because 1 optionToken locks
             // 1 unit of collateral token
             return _underlyingAmount;
@@ -453,11 +451,11 @@ contract SeriesController is
             (((_underlyingAmount * _price) / (uint256(10)**priceDecimals)) *
                 (uint256(10) **
                     (
-                        IERC20Lib(currentSeries.tokens.collateralToken)
+                        IERC20Lib(_currentSeries.tokens.collateralToken)
                             .decimals()
                     ))) /
             (uint256(10) **
-                (IERC20Lib(currentSeries.tokens.underlyingToken).decimals()));
+                (IERC20Lib(_currentSeries.tokens.underlyingToken).decimals()));
     }
 
     /// @notice Returns the settlement price for this Series.

--- a/test/amm/minterAmmPut.ts
+++ b/test/amm/minterAmmPut.ts
@@ -300,9 +300,10 @@ contract("AMM Put Verification", (accounts) => {
 
     const capitalAmount = 10_000
     // 10_000 * 150
+    const series = await deployedSeriesController.series(seriesId)
     const capitalCollateral =
       await deployedSeriesController.getCollateralPerOptionToken(
-        seriesId,
+        series,
         capitalAmount,
       )
 
@@ -340,7 +341,7 @@ contract("AMM Put Verification", (accounts) => {
     const aliceAmount = 1_000
     const aliceCollateral =
       await deployedSeriesController.getCollateralPerOptionToken(
-        seriesId,
+        series,
         aliceAmount,
       )
 
@@ -417,7 +418,7 @@ contract("AMM Put Verification", (accounts) => {
     // 3000 * 150
     const bTokenBuyCollateral =
       await deployedSeriesController.getCollateralPerOptionToken(
-        seriesId,
+        series,
         bTokenBuyAmount,
       )
     let ammCollateralAmount =
@@ -462,7 +463,7 @@ contract("AMM Put Verification", (accounts) => {
     const bobAmount = 1_000
     const bobCollateral =
       await deployedSeriesController.getCollateralPerOptionToken(
-        seriesId,
+        series,
         bobAmount,
       ) // 150_000
     await collateralToken.mint(bobAccount, bobCollateral)

--- a/test/amm/pricing.ts
+++ b/test/amm/pricing.ts
@@ -108,7 +108,11 @@ contract("AMM Pricing", (accounts) => {
         10000,
       )
 
-    assertBNEq(maximumCollateral, 154329)
+    assertBNEq(
+      maximumCollateral,
+      154329,
+      "Incorent maximumCollateral value for bToken",
+    )
 
     const series = await deployedSeriesController.series(seriesId)
     const maximumCollateralForNewSeries =
@@ -117,7 +121,11 @@ contract("AMM Pricing", (accounts) => {
         deployedAmm.address,
         10000,
       )
-    assertBNEq(maximumCollateralForNewSeries, maximumCollateral)
+    assertBNEq(
+      maximumCollateralForNewSeries,
+      maximumCollateral,
+      "MaximumCollateral should be equal for existent series and non existent series",
+    )
 
     ret = await deployedAmm.bTokenBuy(seriesId, 10000, maximumCollateral, {
       from: aliceAccount,
@@ -220,7 +228,11 @@ contract("AMM Pricing", (accounts) => {
         10000,
       )
 
-    assertBNEq(maximumCollateral, 2315)
+    assertBNEq(
+      maximumCollateral,
+      2315,
+      "Incorent maximumCollateral value for bToken",
+    )
 
     const series = await deployedSeriesController.series(seriesId)
     const maximumCollateralForNewSeries =
@@ -229,7 +241,11 @@ contract("AMM Pricing", (accounts) => {
         deployedAmm.address,
         10000,
       )
-    assertBNEq(maximumCollateralForNewSeries, maximumCollateral)
+    assertBNEq(
+      maximumCollateralForNewSeries,
+      maximumCollateral,
+      "MaximumCollateral should be equal for existent series and non existent series",
+    )
 
     //bTokenGetCollateralInForNewSeries revert testing
     let tokens = {

--- a/test/seriesController/closeSeries.ts
+++ b/test/seriesController/closeSeries.ts
@@ -144,11 +144,11 @@ contract("SeriesController close", (accounts) => {
 
     // Amount we will be minting
     const MINT_AMOUNT = new BN(10000)
-
+    const series = await deployedSeriesController.series(seriesId)
     const collateralAmount = new BN(
       (
         await deployedSeriesController.getCollateralPerOptionToken(
-          seriesId,
+          series,
           MINT_AMOUNT,
         )
       ).toString(),

--- a/test/seriesController/seriesScenarios.ts
+++ b/test/seriesController/seriesScenarios.ts
@@ -229,9 +229,10 @@ contract("Series Scenarios", (accounts) => {
     // Bob mints options by locking up USDC, but because it's a put
     // we first need to convert the bToken amount into its equivalent
     // collateral (USDC) amount (which will be 12k * 1e6 * mintAmount)
+    const series = await deployedSeriesController.series(seriesId)
     const mintCollateralEquivalent =
       await deployedSeriesController.getCollateralPerOptionToken(
-        seriesId,
+        series,
         mintAmount,
       )
 


### PR DESCRIPTION
Current implementation only provides methods to get pricing for series that already exist in the system (`AmmDataProvider.getPriceForSeries`, `AmmDataProvider.bTokenGetCollateralInView`). In order to complete the auto-series-creation project we need versions of these methods that instead of `seriesId` take `ISeriesController.Series` object. These 2 methods will allow the front-end code to calculate pricing for nonexistent series. 