### PR TITLE
Revert "pricing for non existent series"

### DIFF
--- a/contracts/amm/AmmDataProvider.sol
+++ b/contracts/amm/AmmDataProvider.sol
@@ -60,42 +60,36 @@ contract AmmDataProvider is IAmmDataProvider {
     /// Given price of bToken we determine what is the largest pool we can create such that
     /// the ratio of its reserves satisfy the given bToken price: Rb / Rw = (1 - Pb) / Pb
     function getVirtualReserves(
-        ISeriesController.Series memory series,
+        uint64 seriesId,
         address ammAddress,
         uint256 collateralTokenBalance,
         uint256 bTokenPrice
     ) public view override returns (uint256, uint256) {
-        //We set wTokenBalance = 0
-        uint256 wTokenBalance = 0;
-        //We commenting this out, but in the furute for perpetuals we will need it
-        /*
+        // Get residual balances
+        uint256 bTokenBalance = 0; // no bTokens are allowed in the pool
         uint256 wTokenBalance = erc1155Controller.balanceOf(
             ammAddress,
             SeriesLibrary.wTokenIndex(seriesId)
         );
-        if (series.isPutOption) {
-            wTokenBalance = seriesController.getCollateralPerOptionToken(
-                series,
-                wTokenBalance
-            );
-        }*/
 
-        IMinterAmm amm = IMinterAmm(ammAddress);
-
-        // Get residual balances
-        uint256 bTokenBalance = 0; // no bTokens are allowed in the pool
+        ISeriesController.Series memory series = seriesController.series(
+            seriesId
+        );
 
         // For put convert token balances into collateral locked in them
         uint256 lockedUnderlyingValue = 1e18;
         if (series.isPutOption) {
-            // TODO: this logic causes the underlying price to be fetched twice from the oracle.
-            //Can be optimized.
+            wTokenBalance = seriesController.getCollateralPerOptionToken(
+                seriesId,
+                wTokenBalance
+            );
+            // TODO: this logic causes the underlying price to be fetched twice from the oracle. Can be optimized.
             lockedUnderlyingValue =
                 (lockedUnderlyingValue * series.strikePrice) /
                 IPriceOracle(addressesProvider.getPriceOracle())
                     .getCurrentPrice(
-                        address(amm.underlyingToken()),
-                        address(amm.priceToken())
+                        seriesController.underlyingToken(seriesId),
+                        seriesController.priceToken(seriesId)
                     );
         }
 
@@ -149,13 +143,13 @@ contract AmmDataProvider is IAmmDataProvider {
     /// given Series
     /// @notice The premium depends on the amount of collateral token in the pool, the reserves
     /// of bToken and wToken in the pool, and the current series price of the underlying
-    /// @param series The Series to buy bToken on
+    /// @param seriesId The ID of the Series to buy bToken on
     /// @param ammAddress The AMM whose reserves we'll use
     /// @param bTokenAmount The amount of bToken to buy, which uses the same decimals as
     /// the underlying ERC20 token
     /// @return The amount of collateral token necessary to buy bTokenAmount worth of bTokens
     function bTokenGetCollateralIn(
-        ISeriesController.Series memory series,
+        uint64 seriesId,
         address ammAddress,
         uint256 bTokenAmount,
         uint256 collateralTokenBalance,
@@ -163,14 +157,15 @@ contract AmmDataProvider is IAmmDataProvider {
     ) public view override returns (uint256) {
         // Shortcut for 0 amount
         if (bTokenAmount == 0) return 0;
+
         bTokenAmount = seriesController.getCollateralPerOptionToken(
-            series,
+            seriesId,
             bTokenAmount
         );
 
         // For both puts and calls balances are expressed in collateral token
         (uint256 bTokenBalance, uint256 wTokenBalance) = getVirtualReserves(
-            series,
+            seriesId,
             ammAddress,
             collateralTokenBalance,
             bTokenPrice
@@ -192,7 +187,7 @@ contract AmmDataProvider is IAmmDataProvider {
 
     /// @dev Calculates the amount of collateral token a seller will receive for selling their option tokens,
     /// taking into account the AMM's level of reserves
-    /// @param seriesId The ID of Series
+    /// @param seriesId The ID of the Series
     /// @param ammAddress The AMM whose reserves we'll use
     /// @param optionTokenAmount The amount of option tokens (either bToken or wToken) to be sold
     /// @param collateralTokenBalance The amount of collateral token held by this AMM
@@ -210,16 +205,14 @@ contract AmmDataProvider is IAmmDataProvider {
     ) public view override returns (uint256) {
         // Shortcut for 0 amount
         if (optionTokenAmount == 0) return 0;
-        ISeriesController.Series memory series = seriesController.series(
-            seriesId
-        );
+
         optionTokenAmount = seriesController.getCollateralPerOptionToken(
-            series,
+            seriesId,
             optionTokenAmount
         );
 
         (uint256 bTokenBalance, uint256 wTokenBalance) = getVirtualReserves(
-            series,
+            seriesId,
             ammAddress,
             collateralTokenBalance,
             bTokenPrice
@@ -340,6 +333,7 @@ contract AmmDataProvider is IAmmDataProvider {
         uint256 collateralLeft = totalCollateral;
         for (uint256 i = 0; i < openSeries.length; i++) {
             uint64 seriesId = openSeries[i];
+
             if (
                 seriesController.state(seriesId) ==
                 ISeriesController.SeriesState.OPEN
@@ -352,7 +346,7 @@ contract AmmDataProvider is IAmmDataProvider {
                     lpTokenAmount) / lpTokenSupply;
 
                 uint256 bTokenPrice = getPriceForSeries(
-                    seriesController.series(seriesId),
+                    seriesId,
                     impliedVolatility
                 );
 
@@ -383,21 +377,40 @@ contract AmmDataProvider is IAmmDataProvider {
     /// representing the price as a fraction of 1 collateral token unit
     /// @dev This function assumes that it will only be called on an OPEN Series; if the
     /// Series is EXPIRED, then the expirationDate - block.timestamp will throw an underflow error
-    function getPriceForSeries(
-        ISeriesController.Series memory series,
-        uint256 annualVolatility
-    ) public view override returns (uint256) {
+    function getPriceForSeries(uint64 seriesId, uint256 annualVolatility)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        ISeriesController.Series memory series = seriesController.series(
+            seriesId
+        );
         uint256 underlyingPrice = IPriceOracle(
             addressesProvider.getPriceOracle()
         ).getCurrentPrice(
-                series.tokens.underlyingToken,
-                series.tokens.priceToken
+                seriesController.underlyingToken(seriesId),
+                seriesController.priceToken(seriesId)
             );
+
+        return
+            getPriceForSeriesInternal(
+                series,
+                underlyingPrice,
+                annualVolatility
+            );
+    }
+
+    function getPriceForSeriesInternal(
+        ISeriesController.Series memory series,
+        uint256 underlyingPrice,
+        uint256 annualVolatility
+    ) private view returns (uint256) {
         // Note! This function assumes the underlyingPrice is a valid series
         // price in units of underlyingToken/priceToken. If the onchain price
         // oracle's value were to drift from the true series price, then the bToken price
         // we calculate here would also drift, and will result in undefined
-        // behavior for any functions which call getPriceForSeries
+        // behavior for any functions which call getPriceForSeriesInternal
         (uint256 call, uint256 put) = IBlackScholes(
             addressesProvider.getBlackScholes()
         ).optionPrices(
@@ -464,7 +477,11 @@ contract AmmDataProvider is IAmmDataProvider {
                 ISeriesController.SeriesState.OPEN
             ) {
                 // value all active bTokens and wTokens at current prices
-                uint256 bPrice = getPriceForSeries(series, impliedVolatility);
+                uint256 bPrice = getPriceForSeriesInternal(
+                    series,
+                    underlyingPrice,
+                    impliedVolatility
+                );
                 // wPrice = 1 - bPrice
                 uint256 lockedUnderlyingValue = 1e18;
                 if (series.isPutOption) {
@@ -476,7 +493,7 @@ contract AmmDataProvider is IAmmDataProvider {
                 // uint256 wPrice = lockedUnderlyingValue - bPrice;
                 uint256 tokensValueCollateral = seriesController
                     .getCollateralPerUnderlying(
-                        series,
+                        seriesId,
                         wTokenBalance * (lockedUnderlyingValue - bPrice),
                         underlyingPrice
                     ) / 1e18;
@@ -536,61 +553,14 @@ contract AmmDataProvider is IAmmDataProvider {
         uint256 bTokenAmount
     ) external view override returns (uint256) {
         IMinterAmm amm = IMinterAmm(ammAddress);
-        ISeriesController.Series memory series = seriesController.series(
-            seriesId
-        );
 
         uint256 collateralWithoutFees = bTokenGetCollateralIn(
-            series,
+            seriesId,
             ammAddress,
             bTokenAmount,
             amm.collateralBalance(),
-            getPriceForSeries(series, amm.getVolatility(seriesId))
+            getPriceForSeries(seriesId, amm.getVolatility(seriesId))
         );
-        uint256 tradeFee = amm.calculateFees(
-            bTokenAmount,
-            collateralWithoutFees
-        );
-        return collateralWithoutFees + tradeFee;
-    }
-
-    /// @notice Calculate premium (i.e. the option price) to buy bTokenAmount bTokens for a
-    ///  new Series
-    /// @notice The premium depends on the amount of collateral token in the pool, the reserves
-    /// of bToken and wToken in the pool, and the current series price of the underlying
-    /// @param series The new Series to buy bToken on
-    /// @param bTokenAmount The amount of bToken to buy, which uses the same decimals as
-    /// the underlying ERC20 token
-    /// @param ammAddress adress of the amm
-    /// @return The amount of collateral token necessary to buy bTokenAmount worth of bTokens
-    /// NOTE: This returns the collateral + fee amount
-    function bTokenGetCollateralInForNewSeries(
-        ISeriesController.Series memory series,
-        address ammAddress,
-        uint256 bTokenAmount
-    ) external view override returns (uint256) {
-        IMinterAmm amm = IMinterAmm(ammAddress);
-        require(
-            address(amm.priceToken()) == series.tokens.priceToken,
-            "!priceToken"
-        );
-        require(
-            address(amm.collateralToken()) == series.tokens.collateralToken,
-            "!collateralToken"
-        );
-        require(
-            address(amm.underlyingToken()) == series.tokens.underlyingToken,
-            "!underlyingToken"
-        );
-
-        uint256 collateralWithoutFees = bTokenGetCollateralIn(
-            series,
-            ammAddress,
-            bTokenAmount,
-            amm.collateralBalance(),
-            getPriceForSeries(series, amm.getBaselineVolatility()) // we used here amm.getBaselineVolatility() instead of amm.getVolatility(seriesId)
-        );
-
         uint256 tradeFee = amm.calculateFees(
             bTokenAmount,
             collateralWithoutFees
@@ -614,15 +584,13 @@ contract AmmDataProvider is IAmmDataProvider {
         uint256 bTokenAmount
     ) external view override returns (uint256) {
         IMinterAmm amm = IMinterAmm(ammAddress);
+
         uint256 collateralWithoutFees = optionTokenGetCollateralOut(
             seriesId,
             ammAddress,
             bTokenAmount,
             amm.collateralBalance(),
-            getPriceForSeries(
-                seriesController.series(seriesId),
-                amm.getVolatility(seriesId)
-            ),
+            getPriceForSeries(seriesId, amm.getVolatility(seriesId)),
             true
         );
 
@@ -640,16 +608,14 @@ contract AmmDataProvider is IAmmDataProvider {
         uint256 wTokenAmount
     ) external view override returns (uint256) {
         IMinterAmm amm = IMinterAmm(ammAddress);
+
         return
             optionTokenGetCollateralOut(
                 seriesId,
                 ammAddress,
                 wTokenAmount,
                 amm.collateralBalance(),
-                getPriceForSeries(
-                    seriesController.series(seriesId),
-                    amm.getVolatility(seriesId)
-                ),
+                getPriceForSeries(seriesId, amm.getVolatility(seriesId)),
                 false
             );
     }

--- a/contracts/amm/IAmmDataProvider.sol
+++ b/contracts/amm/IAmmDataProvider.sol
@@ -2,18 +2,16 @@
 
 pragma solidity 0.8.0;
 
-import "../series/ISeriesController.sol";
-
 interface IAmmDataProvider {
     function getVirtualReserves(
-        ISeriesController.Series memory series,
+        uint64 seriesId,
         address ammAddress,
         uint256 collateralTokenBalance,
         uint256 bTokenPrice
     ) external view returns (uint256, uint256);
 
     function bTokenGetCollateralIn(
-        ISeriesController.Series memory series,
+        uint64 seriesId,
         address ammAddress,
         uint256 bTokenAmount,
         uint256 collateralTokenBalance,
@@ -43,10 +41,10 @@ interface IAmmDataProvider {
         uint256 impliedVolatility
     ) external view returns (uint256);
 
-    function getPriceForSeries(
-        ISeriesController.Series memory series,
-        uint256 annualVolatility
-    ) external view returns (uint256);
+    function getPriceForSeries(uint64 seriesId, uint256 annualVolatility)
+        external
+        view
+        returns (uint256);
 
     function getTotalPoolValue(
         bool includeUnclaimed,
@@ -69,12 +67,6 @@ interface IAmmDataProvider {
     function bTokenGetCollateralInView(
         address ammAddress,
         uint64 seriesId,
-        uint256 bTokenAmount
-    ) external view returns (uint256);
-
-    function bTokenGetCollateralInForNewSeries(
-        ISeriesController.Series memory series,
-        address ammAddress,
         uint256 bTokenAmount
     ) external view returns (uint256);
 

--- a/contracts/amm/MinterAmm.sol
+++ b/contracts/amm/MinterAmm.sol
@@ -712,12 +712,10 @@ contract MinterAmm is
     /// representing the price as a fraction of 1 collateral token unit
     function getPriceForSeries(uint64 seriesId) public view returns (uint256) {
         require(openSeries.contains(seriesId), "E13");
-        ISeriesController.Series memory series = seriesController.series(
-            seriesId
-        );
+
         return
             getAmmDataProvider().getPriceForSeries(
-                series,
+                seriesId,
                 getVolatility(seriesId)
             );
     }
@@ -796,13 +794,10 @@ contract MinterAmm is
 
         // Mint required number of bTokens for the direct buy (if required)
         if (bTokenBalance < senderAmount) {
-            ISeriesController.Series memory series = seriesController.series(
-                seriesId
-            );
             // Approve the collateral to mint bTokenAmount of new options
             uint256 bTokenCollateralAmount = seriesController
                 .getCollateralPerOptionToken(
-                    series,
+                    seriesId,
                     senderAmount - bTokenBalance
                 );
 
@@ -869,9 +864,6 @@ contract MinterAmm is
             "E22" // Series has expired
         );
         uint256 collateralAmount;
-        ISeriesController.Series memory series = seriesController.series(
-            seriesId
-        );
         {
             uint256 underlyingPrice = getCurrentUnderlyingPrice();
             (uint256 price, uint256 vega) = calculatePriceAndVega(
@@ -881,7 +873,7 @@ contract MinterAmm is
             require(price > 0, "E17");
 
             collateralAmount = getAmmDataProvider().bTokenGetCollateralIn(
-                series,
+                seriesId,
                 address(this),
                 bTokenAmount,
                 collateralBalance(),
@@ -890,7 +882,7 @@ contract MinterAmm is
             require(
                 collateralAmount * 1e18 >=
                     seriesController.getCollateralPerUnderlying(
-                        series,
+                        seriesId,
                         price * bTokenAmount,
                         underlyingPrice
                     ),
@@ -903,7 +895,7 @@ contract MinterAmm is
                     priceImpact =
                         (collateralAmount * 1e26) /
                         seriesController.getCollateralPerUnderlying(
-                            series,
+                            seriesId,
                             bTokenAmount,
                             1e8
                         ) /
@@ -947,7 +939,7 @@ contract MinterAmm is
 
         // Approve the collateral to mint bTokenAmount of new options
         uint256 bTokenCollateralAmount = seriesController
-            .getCollateralPerOptionToken(series, bTokenAmount);
+            .getCollateralPerOptionToken(seriesId, bTokenAmount);
 
         collateralToken.approve(
             address(seriesController),
@@ -998,9 +990,6 @@ contract MinterAmm is
             "E22" // Series has expired
         );
         uint256 collateralAmount;
-        ISeriesController.Series memory series = seriesController.series(
-            seriesId
-        );
         {
             uint256 underlyingPrice = getCurrentUnderlyingPrice();
             (uint256 price, uint256 vega) = calculatePriceAndVega(
@@ -1016,11 +1005,10 @@ contract MinterAmm is
                 price,
                 true
             );
-
             require(
                 collateralAmount * 1e18 <=
                     seriesController.getCollateralPerUnderlying(
-                        series,
+                        seriesId,
                         price * bTokenAmount,
                         underlyingPrice
                     ),
@@ -1034,7 +1022,7 @@ contract MinterAmm is
                         price -
                         (collateralAmount * 1e26) /
                         seriesController.getCollateralPerUnderlying(
-                            series,
+                            seriesId,
                             bTokenAmount,
                             1e8
                         ) /

--- a/contracts/amm/WTokenVault.sol
+++ b/contracts/amm/WTokenVault.sol
@@ -136,12 +136,12 @@ contract WTokenVault is OwnableUpgradeable, Proxiable, IWTokenVault {
 
                 uint256 bPrice = IAmmDataProvider(
                     addressesProvider.getAmmDataProvider()
-                ).getPriceForSeries(series, vars.volatility);
+                ).getPriceForSeries(seriesId, vars.volatility);
 
                 uint256 valuePerToken;
                 if (series.isPutOption) {
                     valuePerToken = seriesController.getCollateralPerUnderlying(
-                            series,
+                            seriesId,
                             (series.strikePrice * 1e18) /
                                 vars.underlyingPrice -
                                 bPrice,
@@ -334,12 +334,12 @@ contract WTokenVault is OwnableUpgradeable, Proxiable, IWTokenVault {
 
                 uint256 bPrice = IAmmDataProvider(
                     addressesProvider.getAmmDataProvider()
-                ).getPriceForSeries(series, vars.volatility);
+                ).getPriceForSeries(seriesId, vars.volatility);
 
                 uint256 valuePerToken;
                 if (series.isPutOption) {
                     valuePerToken = seriesController.getCollateralPerUnderlying(
-                            series,
+                            seriesId,
                             (series.strikePrice * 1e18) /
                                 vars.underlyingPrice -
                                 bPrice,

--- a/contracts/series/ISeriesController.sol
+++ b/contracts/series/ISeriesController.sol
@@ -209,12 +209,12 @@ interface ISeriesController {
     function isPutOption(uint64 _seriesId) external view returns (bool);
 
     function getCollateralPerOptionToken(
-        ISeriesController.Series memory _currentSeries,
+        uint64 _seriesId,
         uint256 _optionTokenAmount
     ) external view returns (uint256);
 
     function getCollateralPerUnderlying(
-        ISeriesController.Series memory _currentSeries,
+        uint64 _seriesId,
         uint256 _underlyingAmount,
         uint256 _price
     ) external view returns (uint256);

--- a/test/amm/minterAmmPut.ts
+++ b/test/amm/minterAmmPut.ts
@@ -300,10 +300,9 @@ contract("AMM Put Verification", (accounts) => {
 
     const capitalAmount = 10_000
     // 10_000 * 150
-    const series = await deployedSeriesController.series(seriesId)
     const capitalCollateral =
       await deployedSeriesController.getCollateralPerOptionToken(
-        series,
+        seriesId,
         capitalAmount,
       )
 
@@ -341,7 +340,7 @@ contract("AMM Put Verification", (accounts) => {
     const aliceAmount = 1_000
     const aliceCollateral =
       await deployedSeriesController.getCollateralPerOptionToken(
-        series,
+        seriesId,
         aliceAmount,
       )
 
@@ -418,7 +417,7 @@ contract("AMM Put Verification", (accounts) => {
     // 3000 * 150
     const bTokenBuyCollateral =
       await deployedSeriesController.getCollateralPerOptionToken(
-        series,
+        seriesId,
         bTokenBuyAmount,
       )
     let ammCollateralAmount =
@@ -463,7 +462,7 @@ contract("AMM Put Verification", (accounts) => {
     const bobAmount = 1_000
     const bobCollateral =
       await deployedSeriesController.getCollateralPerOptionToken(
-        series,
+        seriesId,
         bobAmount,
       ) // 150_000
     await collateralToken.mint(bobAccount, bobCollateral)

--- a/test/amm/pricing.ts
+++ b/test/amm/pricing.ts
@@ -1,18 +1,16 @@
-import { expectEvent, time, expectRevert } from "@openzeppelin/test-helpers"
+import { expectEvent, time } from "@openzeppelin/test-helpers"
 import { contract } from "hardhat"
 import {
   SimpleTokenInstance,
   MinterAmmInstance,
   AmmDataProviderInstance,
   ERC1155ControllerInstance,
-  SeriesControllerInstance,
 } from "../../typechain"
 
 let deployedAmm: MinterAmmInstance
 let deployedAmmDataProvider: AmmDataProviderInstance
 let deployedERC1155Controller: ERC1155ControllerInstance
 let collateralToken: SimpleTokenInstance
-let deployedSeriesController: SeriesControllerInstance
 
 let seriesId: string
 let expiration: number
@@ -38,7 +36,6 @@ contract("AMM Pricing", (accounts) => {
       deployedAmmDataProvider,
       seriesId,
       deployedERC1155Controller,
-      deployedSeriesController,
       expiration,
     } = await setupAllTestContracts({
       oraclePrice: BTC_ORACLE_PRICE,
@@ -108,24 +105,7 @@ contract("AMM Pricing", (accounts) => {
         10000,
       )
 
-    assertBNEq(
-      maximumCollateral,
-      154329,
-      "Incorent maximumCollateral value for bToken",
-    )
-
-    const series = await deployedSeriesController.series(seriesId)
-    const maximumCollateralForNewSeries =
-      await deployedAmmDataProvider.bTokenGetCollateralInForNewSeries(
-        series,
-        deployedAmm.address,
-        10000,
-      )
-    assertBNEq(
-      maximumCollateralForNewSeries,
-      maximumCollateral,
-      "MaximumCollateral should be equal for existent series and non existent series",
-    )
+    assertBNEq(maximumCollateral, 154329)
 
     ret = await deployedAmm.bTokenBuy(seriesId, 10000, maximumCollateral, {
       from: aliceAccount,
@@ -186,7 +166,6 @@ contract("AMM Pricing", (accounts) => {
       seriesId,
       deployedERC1155Controller,
       deployedAmmDataProvider,
-      deployedSeriesController,
       expiration,
     } = await setupAllTestContracts({
       oraclePrice: BTC_ORACLE_PRICE,
@@ -218,94 +197,6 @@ contract("AMM Pricing", (accounts) => {
       await collateralToken.balanceOf(deployedAmm.address),
       10000,
       "Collateral should have been used to mint",
-    )
-
-    // Buy bTokens
-    const maximumCollateral =
-      await deployedAmmDataProvider.bTokenGetCollateralInView(
-        deployedAmm.address,
-        seriesId,
-        10000,
-      )
-
-    assertBNEq(
-      maximumCollateral,
-      2315,
-      "Incorent maximumCollateral value for bToken",
-    )
-
-    const series = await deployedSeriesController.series(seriesId)
-    const maximumCollateralForNewSeries =
-      await deployedAmmDataProvider.bTokenGetCollateralInForNewSeries(
-        series,
-        deployedAmm.address,
-        10000,
-      )
-    assertBNEq(
-      maximumCollateralForNewSeries,
-      maximumCollateral,
-      "MaximumCollateral should be equal for existent series and non existent series",
-    )
-
-    //bTokenGetCollateralInForNewSeries revert testing
-    let tokens = {
-      ...series.tokens,
-    }
-    let seriesRevert
-
-    seriesRevert = {
-      expirationDate: "1648800000",
-      isPutOption: false,
-      strikePrice: "1500000000000",
-      tokens: { ...tokens },
-    }
-    // 0x29D7d1dd5B6f9C864d9db560D72a247c178aE86B is some random address from internet
-    // Check revert for priceToken
-    seriesRevert.tokens.priceToken =
-      "0x29D7d1dd5B6f9C864d9db560D72a247c178aE86B"
-    await expectRevert(
-      deployedAmmDataProvider.bTokenGetCollateralInForNewSeries(
-        seriesRevert,
-        deployedAmm.address,
-        10000,
-      ),
-      "!priceToken",
-    )
-
-    // Check revert for collateralToken
-    seriesRevert = {
-      expirationDate: "1648800000",
-      isPutOption: false,
-      strikePrice: "1500000000000",
-      tokens: { ...tokens },
-    }
-    seriesRevert.tokens.collateralToken =
-      "0x29D7d1dd5B6f9C864d9db560D72a247c178aE86B"
-    await expectRevert(
-      deployedAmmDataProvider.bTokenGetCollateralInForNewSeries(
-        seriesRevert,
-        deployedAmm.address,
-        10000,
-      ),
-      "!collateralToken",
-    )
-
-    // Check revert for underlyingToken
-    seriesRevert = {
-      expirationDate: "1648800000",
-      isPutOption: false,
-      strikePrice: "1500000000000",
-      tokens: { ...tokens },
-    }
-    seriesRevert.tokens.underlyingToken =
-      "0x29D7d1dd5B6f9C864d9db560D72a247c178aE86B"
-    await expectRevert(
-      deployedAmmDataProvider.bTokenGetCollateralInForNewSeries(
-        seriesRevert,
-        deployedAmm.address,
-        10000,
-      ),
-      "!underlyingToken",
     )
 
     const startTime = expiration - ONE_WEEK_DURATION

--- a/test/seriesController/closeSeries.ts
+++ b/test/seriesController/closeSeries.ts
@@ -144,11 +144,11 @@ contract("SeriesController close", (accounts) => {
 
     // Amount we will be minting
     const MINT_AMOUNT = new BN(10000)
-    const series = await deployedSeriesController.series(seriesId)
+
     const collateralAmount = new BN(
       (
         await deployedSeriesController.getCollateralPerOptionToken(
-          series,
+          seriesId,
           MINT_AMOUNT,
         )
       ).toString(),

--- a/test/seriesController/seriesScenarios.ts
+++ b/test/seriesController/seriesScenarios.ts
@@ -231,10 +231,9 @@ contract("Series Scenarios", (accounts) => {
     // Bob mints options by locking up USDC, but because it's a put
     // we first need to convert the bToken amount into its equivalent
     // collateral (USDC) amount (which will be 12k * 1e6 * mintAmount)
-    const series = await deployedSeriesController.series(seriesId)
     const mintCollateralEquivalent =
       await deployedSeriesController.getCollateralPerOptionToken(
-        series,
+        seriesId,
         mintAmount,
       )
 


### PR DESCRIPTION
I'm reverting this. It was merged prematurely. One issue is the change from using `getPriceForSeriesInternal` to `getPriceForSeries` in the `getTotalPoolValue`, which results in the underlying price being repeatedly requested for each series. After this revert is merged @lukaskiss222 could you create a PR again with you changes and let's not merge it until I approve as well.