### PR TITLE
Fixed approval for series deployer

### DIFF
--- a/contracts/series/SeriesDeployer.sol
+++ b/contracts/series/SeriesDeployer.sol
@@ -297,7 +297,7 @@ contract SeriesDeployer is
         if (remainingBalance > 0) {
             // Give allowane just in case
             IERC20(ammTokens.collateralToken).approve(
-                msg.sender,
+                address(this),
                 remainingBalance
             );
 

--- a/contracts/series/SeriesDeployer.sol
+++ b/contracts/series/SeriesDeployer.sol
@@ -273,7 +273,7 @@ contract SeriesDeployer is
 
         {
             // Buy options
-            uint256 amtBought = IMinterAmm(_existingAmm).bTokenBuy(
+            uint256 collateralAmount = IMinterAmm(_existingAmm).bTokenBuy(
                 createdSeriesId,
                 _bTokenAmount,
                 _collateralMaximum
@@ -285,7 +285,7 @@ contract SeriesDeployer is
                 address(this),
                 msg.sender,
                 SeriesLibrary.bTokenIndex(createdSeriesId),
-                amtBought,
+                _bTokenAmount,
                 data
             );
         }

--- a/test/seriesController/autoCreateSeries.ts
+++ b/test/seriesController/autoCreateSeries.ts
@@ -475,7 +475,7 @@ contract("Auto Series Creation", (accounts) => {
     )
   })
 
-  it.only("Checks that reaming balance is returned to the user", async () => {
+  it("Checks that reaming balance is returned to the user", async () => {
     ;({
       underlyingToken,
       collateralToken,

--- a/test/seriesController/autoCreateSeries.ts
+++ b/test/seriesController/autoCreateSeries.ts
@@ -474,4 +474,78 @@ contract("Auto Series Creation", (accounts) => {
       "seriesPerExpirationLimit should be correct",
     )
   })
+
+  it.only("Checks that reaming balance is returned to the user", async () => {
+    ;({
+      underlyingToken,
+      collateralToken,
+      priceToken,
+      deployedSeriesController,
+      expiration,
+      deployedAmm,
+      deployedAddressesProvider,
+      deployedERC1155Controller,
+      deployedSeriesDeployer,
+    } = await setupAllTestContracts({
+      strikePrice: STRIKE_PRICE.toString(),
+      oraclePrice: UNDERLYING_PRICE,
+      annualizedVolatility: ANNUALIZED_VOLATILITY,
+    }))
+
+    // Add a new expiration
+    const newExpiration = expiration + ONE_WEEK_DURATION
+    await deployedSeriesController.updateAllowedExpirations([newExpiration])
+
+    // Mint and approve tokens
+    await underlyingToken.mint(aliceAccount, 10e8)
+    await underlyingToken.approve(deployedSeriesDeployer.address, 10e8, {
+      from: aliceAccount,
+    })
+
+    // Get the index count
+    const beforeCount = await deployedSeriesController.latestIndex()
+
+    await deployedSeriesDeployer.updateAllowedTokenStrikeRanges(
+      underlyingToken.address,
+      50, // min 50% of underlying price
+      150, // max 150% of underlying price
+      1e8,
+    )
+
+    // Create the series and buy tokens
+    await deployedSeriesDeployer.autoCreateSeriesAndBuy(
+      deployedAmm.address,
+      STRIKE_PRICE,
+      newExpiration,
+      false,
+      1e8,
+      1e9,
+      {
+        from: aliceAccount,
+      },
+    )
+
+    // Ensure the series index was incremented to show the series was created
+    const afterCount = await deployedSeriesController.latestIndex()
+    assert(
+      afterCount.eq(beforeCount.add(new BN(1))),
+      "New series should update index",
+    )
+
+    // Verify bTokens - series ID is current - 1
+    const bTokenIndex = await deployedSeriesController.bTokenIndex(beforeCount)
+    assertBNEq(
+      await deployedERC1155Controller.balanceOf(aliceAccount, bTokenIndex),
+      1e8,
+      "bTokens should be purchased",
+    )
+
+    // Verify Alice got back unused collateral back
+    const collateralBalance = await underlyingToken.balanceOf(aliceAccount)
+    assertBNEq(
+      collateralBalance,
+      9e8,
+      "Alice should have 9e8 collateral returned to her",
+    )
+  })
 })


### PR DESCRIPTION
I changed the approval from msg.sender to address(this) because we should be giving approval to the deployer contract not to the sender because we need to send reaming tokens back to the user from the deployer.